### PR TITLE
Rename DataFrame methods for more concise API

### DIFF
--- a/cloud_dataframe/backends/duckdb/sql_generator.py
+++ b/cloud_dataframe/backends/duckdb/sql_generator.py
@@ -374,11 +374,11 @@ def _generate_group_by(df: DataFrame) -> str:
     Returns:
         The generated SQL string for the GROUP BY clause
     """
-    if not df.group_by or not df.group_by.columns:
+    if not df.group_by_clause or not df.group_by_clause.columns:
         return ""
     
     group_by_cols = []
-    for col in df.group_by.columns:
+    for col in df.group_by_clause.columns:
         col_sql = _generate_expression(col)
         group_by_cols.append(col_sql)
     
@@ -412,12 +412,12 @@ def _generate_order_by(df: DataFrame) -> str:
     Returns:
         The generated SQL string for the ORDER BY clause
     """
-    if not df.order_by:
+    if not df.order_by_clauses:
         return ""
     
     order_by_parts = []
     
-    for clause in df.order_by:
+    for clause in df.order_by_clauses:
         expr_sql = _generate_expression(clause.expression)
         direction_sql = clause.direction.value
         order_by_parts.append(f"{expr_sql} {direction_sql}")

--- a/cloud_dataframe/core/dataframe.py
+++ b/cloud_dataframe/core/dataframe.py
@@ -118,9 +118,9 @@ class DataFrame:
         self.columns: List[Column] = []
         self.source: Optional[DataSource] = None
         self.filter_condition: Optional[FilterCondition] = None
-        self.group_by: Optional[GroupByClause] = None
+        self.group_by_clause: Optional[GroupByClause] = None
         self.having: Optional[FilterCondition] = None
-        self.order_by: List[OrderByClause] = []
+        self.order_by_clauses: List[OrderByClause] = []
         self.limit_value: Optional[int] = None
         self.offset_value: Optional[int] = None
         self.distinct: bool = False
@@ -155,7 +155,7 @@ class DataFrame:
         return self
     
     @classmethod
-    def from_table(cls, table_name: str, schema: Optional[str] = None, alias: Optional[str] = None) -> 'DataFrame':
+    def from_(cls, table_name: str, schema: Optional[str] = None, alias: Optional[str] = None) -> 'DataFrame':
         """
         Create a new DataFrame from a database table.
         
@@ -233,7 +233,7 @@ class DataFrame:
             right=LiteralExpression(value=True)
         )
     
-    def group_by_columns(self, *columns: Union[str, Expression, ColSpec]) -> 'DataFrame':
+    def group_by(self, *columns: Union[str, Expression, ColSpec]) -> 'DataFrame':
         """
         Group the DataFrame by the specified columns.
         
@@ -252,10 +252,10 @@ class DataFrame:
             else:
                 expressions.append(col)
         
-        self.group_by = GroupByClause(columns=expressions)
+        self.group_by_clause = GroupByClause(columns=expressions)
         return self
     
-    def order_by_columns(self, *clauses: Union[OrderByClause, Expression, str, ColSpec], 
+    def order_by(self, *clauses: Union[OrderByClause, Expression, str, ColSpec], 
                  desc: bool = False) -> 'DataFrame':
         """
         Order the DataFrame by the specified columns.
@@ -271,19 +271,19 @@ class DataFrame:
         
         for clause in clauses:
             if isinstance(clause, OrderByClause):
-                self.order_by.append(clause)
+                self.order_by_clauses.append(clause)
             elif isinstance(clause, str):
-                self.order_by.append(OrderByClause(
+                self.order_by_clauses.append(OrderByClause(
                     expression=ColumnReference(clause),
                     direction=direction
                 ))
             elif isinstance(clause, ColSpec):
-                self.order_by.append(OrderByClause(
+                self.order_by_clauses.append(OrderByClause(
                     expression=ColumnReference(clause.name),
                     direction=direction
                 ))
             else:
-                self.order_by.append(OrderByClause(
+                self.order_by_clauses.append(OrderByClause(
                     expression=clause,
                     direction=direction
                 ))

--- a/cloud_dataframe/examples/basic_usage.py
+++ b/cloud_dataframe/examples/basic_usage.py
@@ -38,7 +38,7 @@ class Department:
 def basic_operations():
     """Demonstrate basic dataframe operations."""
     # Create a DataFrame from a table
-    df = DataFrame.from_table("employees")
+    df = DataFrame.from_("employees")
     
     # Select specific columns
     df_select = df.select(
@@ -51,7 +51,7 @@ def basic_operations():
     df_filter = df.filter(lambda x: x.salary > 50000)
     
     # Group by and aggregate
-    df_group = df.group_by_columns("department") \
+    df_group = df.group_by("department") \
         .select(
             as_column(col("department"), "department"),
             as_column(count("*"), "employee_count"),
@@ -59,7 +59,7 @@ def basic_operations():
         )
     
     # Order by
-    df_order = df.order_by_columns("salary", desc=True)
+    df_order = df.order_by("salary", desc=True)
     
     # Limit and offset
     df_limit = df.limit(10).offset(5)
@@ -80,8 +80,8 @@ def basic_operations():
 def join_operations():
     """Demonstrate join operations."""
     # Create DataFrames from tables
-    employees = DataFrame.from_table("employees", alias="e")
-    departments = DataFrame.from_table("departments", alias="d")
+    employees = DataFrame.from_("employees", alias="e")
+    departments = DataFrame.from_("departments", alias="d")
     
     # Inner join
     inner_join = employees.join(
@@ -164,8 +164,8 @@ def execute_query():
     """)
     
     # Create a DataFrame
-    df = DataFrame.from_table("employees") \
-        .group_by_columns("department") \
+    df = DataFrame.from_("employees") \
+        .group_by("department") \
         .select(
             as_column(col("department"), "department"),
             as_column(count("*"), "employee_count"),

--- a/cloud_dataframe/tests/integration/test_sql_generation.py
+++ b/cloud_dataframe/tests/integration/test_sql_generation.py
@@ -38,7 +38,7 @@ class TestDuckDBSQLGeneration(unittest.TestCase):
     
     def test_simple_select(self):
         """Test generating SQL for a simple SELECT query."""
-        df = DataFrame.from_table("employees")
+        df = DataFrame.from_("employees")
         sql = df.to_sql(dialect="duckdb")
         
         print(f"Generated SQL: {sql}")
@@ -50,7 +50,7 @@ class TestDuckDBSQLGeneration(unittest.TestCase):
         df = DataFrame.create_select(
             as_column(col("id"), "id"),
             as_column(col("name"), "name")
-        ).from_table("employees")
+        ).from_("employees")
         
         sql = df.to_sql(dialect="duckdb")
         expected_sql = "SELECT id AS id, name AS name\nFROM employees"
@@ -58,7 +58,7 @@ class TestDuckDBSQLGeneration(unittest.TestCase):
     
     def test_filter(self):
         """Test generating SQL for a filtered query."""
-        df = DataFrame.from_table("employees").filter(
+        df = DataFrame.from_("employees").filter(
             BinaryOperation(
                 left=col("salary"),
                 operator=">",
@@ -72,8 +72,8 @@ class TestDuckDBSQLGeneration(unittest.TestCase):
     
     def test_group_by(self):
         """Test generating SQL for a GROUP BY query."""
-        df = DataFrame.from_table("employees") \
-            .group_by_columns("department") \
+        df = DataFrame.from_("employees") \
+            .group_by("department") \
             .select(
                 as_column(col("department"), "department"),
                 as_column(count("*"), "employee_count"),
@@ -86,8 +86,8 @@ class TestDuckDBSQLGeneration(unittest.TestCase):
     
     def test_order_by(self):
         """Test generating SQL for an ORDER BY query."""
-        df = DataFrame.from_table("employees") \
-            .order_by_columns("salary", desc=True)
+        df = DataFrame.from_("employees") \
+            .order_by("salary", desc=True)
         
         sql = df.to_sql(dialect="duckdb")
         expected_sql = "SELECT *\nFROM employees\nORDER BY salary DESC"
@@ -95,7 +95,7 @@ class TestDuckDBSQLGeneration(unittest.TestCase):
     
     def test_limit_offset(self):
         """Test generating SQL for a query with LIMIT and OFFSET."""
-        df = DataFrame.from_table("employees") \
+        df = DataFrame.from_("employees") \
             .limit(10) \
             .offset(5)
         
@@ -105,7 +105,7 @@ class TestDuckDBSQLGeneration(unittest.TestCase):
     
     def test_distinct(self):
         """Test generating SQL for a DISTINCT query."""
-        df = DataFrame.from_table("employees") \
+        df = DataFrame.from_("employees") \
             .distinct_rows() \
             .select(
                 as_column(col("department"), "department")
@@ -117,8 +117,8 @@ class TestDuckDBSQLGeneration(unittest.TestCase):
     
     def test_join(self):
         """Test generating SQL for a JOIN query."""
-        employees = DataFrame.from_table("employees", alias="e")
-        departments = DataFrame.from_table("departments", alias="d")
+        employees = DataFrame.from_("employees", alias="e")
+        departments = DataFrame.from_("departments", alias="d")
         
         joined_df = employees.join(
             departments,
@@ -135,8 +135,8 @@ class TestDuckDBSQLGeneration(unittest.TestCase):
     
     def test_left_join(self):
         """Test generating SQL for a LEFT JOIN query."""
-        employees = DataFrame.from_table("employees", alias="e")
-        departments = DataFrame.from_table("departments", alias="d")
+        employees = DataFrame.from_("employees", alias="e")
+        departments = DataFrame.from_("departments", alias="d")
         
         joined_df = employees.left_join(
             departments,
@@ -153,14 +153,14 @@ class TestDuckDBSQLGeneration(unittest.TestCase):
     
     def test_with_cte(self):
         """Test generating SQL for a query with a CTE."""
-        dept_counts = DataFrame.from_table("employees") \
-            .group_by_columns("department_id") \
+        dept_counts = DataFrame.from_("employees") \
+            .group_by("department_id") \
             .select(
                 as_column(col("department_id"), "department_id"),
                 as_column(count("*"), "employee_count")
             )
         
-        df = DataFrame.from_table("departments", alias="d") \
+        df = DataFrame.from_("departments", alias="d") \
             .with_cte("dept_counts", dept_counts) \
             .join(
                 TableReference(table_name="dept_counts", alias="dc"),

--- a/final_test.py
+++ b/final_test.py
@@ -7,7 +7,7 @@ from cloud_dataframe.type_system.column import col, literal, as_column, count, a
 def main():
     """Run a complete test of SQL generation."""
     # Create a base DataFrame with a source table
-    df = DataFrame.from_table("employees")
+    df = DataFrame.from_("employees")
     
     # Apply filter
     filtered_df = df.filter(
@@ -19,7 +19,7 @@ def main():
     )
     
     # Apply group by
-    grouped_df = filtered_df.group_by_columns("department")
+    grouped_df = filtered_df.group_by("department")
     
     # Apply select
     result_df = grouped_df.select(


### PR DESCRIPTION
This PR renames DataFrame methods to create a more concise API:
- Renamed from_table to from_
- Renamed group_by_columns to group_by
- Renamed order_by_columns to order_by

All references in tests and examples have been updated to use the new method names.

Link to Devin run: https://app.devin.ai/sessions/b5c0863080c34295a5fb9c9e241a221b
Requested by: Neema Raphael