### PR TITLE
Update join methods to accept lambda expressions

### DIFF
--- a/cloud_dataframe/tests/integration/test_join_lambda.py
+++ b/cloud_dataframe/tests/integration/test_join_lambda.py
@@ -1,0 +1,109 @@
+"""
+Integration tests for lambda-based join operations.
+
+This module contains tests for joining DataFrames using lambda expressions.
+"""
+import unittest
+from dataclasses import dataclass
+from typing import Optional
+
+from cloud_dataframe.core.dataframe import DataFrame
+from cloud_dataframe.type_system.column import col, literal, as_column
+from cloud_dataframe.type_system.decorators import dataclass_to_schema
+
+
+@dataclass
+@dataclass_to_schema()
+class Employee:
+    """Employee dataclass for testing join operations."""
+    id: int
+    name: str
+    department_id: int
+    salary: float
+
+
+@dataclass
+@dataclass_to_schema()
+class Department:
+    """Department dataclass for testing join operations."""
+    id: int
+    name: str
+    location: str
+
+
+class TestJoinWithLambda(unittest.TestCase):
+    """Test cases for lambda-based join operations."""
+    
+    def test_simple_join(self):
+        """Test a simple join with lambda."""
+        employees = DataFrame.from_("employees", alias="e")
+        departments = DataFrame.from_("departments", alias="d")
+        
+        joined_df = employees.join(
+            departments,
+            lambda e, d: e.department_id == d.id
+        )
+        
+        sql = joined_df.to_sql(dialect="duckdb")
+        expected_sql = "SELECT *\nFROM employees AS e INNER JOIN departments AS d ON e.department_id = d.id"
+        self.assertEqual(sql.strip(), expected_sql)
+    
+    def test_left_join(self):
+        """Test a LEFT JOIN with lambda."""
+        employees = DataFrame.from_("employees", alias="e")
+        departments = DataFrame.from_("departments", alias="d")
+        
+        joined_df = employees.left_join(
+            departments,
+            lambda e, d: e.department_id == d.id
+        )
+        
+        sql = joined_df.to_sql(dialect="duckdb")
+        expected_sql = "SELECT *\nFROM employees AS e LEFT JOIN departments AS d ON e.department_id = d.id"
+        self.assertEqual(sql.strip(), expected_sql)
+    
+    def test_right_join(self):
+        """Test a RIGHT JOIN with lambda."""
+        employees = DataFrame.from_("employees", alias="e")
+        departments = DataFrame.from_("departments", alias="d")
+        
+        joined_df = employees.right_join(
+            departments,
+            lambda e, d: e.department_id == d.id
+        )
+        
+        sql = joined_df.to_sql(dialect="duckdb")
+        expected_sql = "SELECT *\nFROM employees AS e RIGHT JOIN departments AS d ON e.department_id = d.id"
+        self.assertEqual(sql.strip(), expected_sql)
+    
+    def test_full_join(self):
+        """Test a FULL JOIN with lambda."""
+        employees = DataFrame.from_("employees", alias="e")
+        departments = DataFrame.from_("departments", alias="d")
+        
+        joined_df = employees.full_join(
+            departments,
+            lambda e, d: e.department_id == d.id
+        )
+        
+        sql = joined_df.to_sql(dialect="duckdb")
+        expected_sql = "SELECT *\nFROM employees AS e FULL JOIN departments AS d ON e.department_id = d.id"
+        self.assertEqual(sql.strip(), expected_sql)
+    
+    def test_complex_join_condition(self):
+        """Test a join with complex condition."""
+        employees = DataFrame.from_("employees", alias="e")
+        departments = DataFrame.from_("departments", alias="d")
+        
+        joined_df = employees.join(
+            departments,
+            lambda e, d: (e.department_id == d.id) and (e.salary > 50000)
+        )
+        
+        sql = joined_df.to_sql(dialect="duckdb")
+        expected_sql = "SELECT *\nFROM employees AS e INNER JOIN departments AS d ON e.department_id = d.id AND e.salary > 50000"
+        self.assertEqual(sql.strip(), expected_sql)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cloud_dataframe/tests/unit/test_type_safety.py
+++ b/cloud_dataframe/tests/unit/test_type_safety.py
@@ -104,7 +104,7 @@ class TestDataclassSchema(unittest.TestCase):
         """Test creating a schema from a dataclass."""
         schema = create_schema_from_dataclass(Employee)
         
-        self.assertEqual(schema.name, "Employee")
+        self.assertEqual(schema.name, "EmployeeTable")
         self.assertEqual(len(schema.columns), 5)
         self.assertEqual(schema.columns["id"], int)
         self.assertEqual(schema.columns["name"], str)
@@ -117,7 +117,7 @@ class TestDataclassSchema(unittest.TestCase):
         col_spec = col_spec_from_dataclass_field(Employee, "salary")
         
         self.assertEqual(col_spec.name, "salary")
-        self.assertEqual(col_spec.table_schema.name, "Employee")
+        self.assertEqual(col_spec.table_schema.name, "EmployeeTable")
         
         # Invalid field
         with self.assertRaises(ValueError):

--- a/cloud_dataframe/type_system/type_checker.py
+++ b/cloud_dataframe/type_system/type_checker.py
@@ -144,8 +144,13 @@ def create_schema_from_dataclass(cls: Type, name: Optional[str] = None) -> Table
     
     type_hints = get_type_hints(cls)
     
+    # Check if the class has a custom name from the decorator
+    custom_name = None
+    if hasattr(cls, "__table_schema__") and getattr(cls, "__table_schema__").name != cls.__name__:
+        custom_name = getattr(cls, "__table_schema__").name
+    
     return TableSchema(
-        name=name or cls.__name__,
+        name=name or custom_name or cls.__name__,
         columns=type_hints
     )
 


### PR DESCRIPTION
This PR updates the join methods to accept lambda expressions for join conditions, similar to what was done for filter methods.

Key changes:
- Added the ability to use lambda expressions for join conditions
- Implemented parsing for join conditions with table aliases
- Added tests for lambda-based join operations
- Removed backward compatibility with BinaryOperation

Link to Devin run: https://app.devin.ai/sessions/b5c0863080c34295a5fb9c9e241a221b
Requested by: Neema Raphael