### PR TITLE
Enhance window functionality with lambda support and frame specifications

### DIFF
--- a/cloud_dataframe/tests/integration/test_window_examples_duckdb.py
+++ b/cloud_dataframe/tests/integration/test_window_examples_duckdb.py
@@ -1,0 +1,185 @@
+"""
+Integration tests for window function examples with DuckDB.
+
+This module contains tests for using frame specifications with window functions
+using the cloud-dataframe library with DuckDB, demonstrating real-world examples.
+"""
+import unittest
+import pandas as pd
+import duckdb
+from typing import Optional
+
+from cloud_dataframe.core.dataframe import DataFrame
+from cloud_dataframe.type_system.schema import TableSchema
+from cloud_dataframe.type_system.column import (
+    as_column, over, row_number, rank, dense_rank, sum, avg,
+    row, range, unbounded
+)
+
+
+class TestWindowExamplesDuckDB(unittest.TestCase):
+    """Test cases for window function examples with DuckDB."""
+    
+    def setUp(self):
+        """Set up test fixtures."""
+        # Create a DuckDB connection
+        self.conn = duckdb.connect(":memory:")
+        
+        # Create sample data
+        sales_data = pd.DataFrame({
+            "product_id": [1, 2, 3, 1, 2, 3, 1, 2, 3],
+            "date": ["2023-01-01", "2023-01-01", "2023-01-01", 
+                    "2023-01-02", "2023-01-02", "2023-01-02",
+                    "2023-01-03", "2023-01-03", "2023-01-03"],
+            "region": ["East", "East", "West", "East", "West", "West", "East", "West", "East"],
+            "sales": [100, 150, 200, 120, 160, 210, 130, 170, 220]
+        })
+        
+        # Register the data in DuckDB
+        self.conn.register("sales_data", sales_data)
+        self.conn.execute("CREATE TABLE sales AS SELECT * FROM sales_data")
+        
+        # Create schema for the sales table
+        self.schema = TableSchema(
+            name="Sales",
+            columns={
+                "product_id": int,
+                "date": str,
+                "region": str,
+                "sales": int,
+            }
+        )
+        
+        # Create a DataFrame with typed properties
+        self.df = DataFrame.from_table_schema("sales", self.schema)
+    
+    def tearDown(self):
+        """Tear down test fixtures."""
+        self.conn.close()
+    
+    def test_running_total_with_unbounded_preceding(self):
+        """Test running total of sales by product_id with unbounded preceding frame."""
+        # Build query with running total
+        query = self.df.select(
+            lambda x: x.product_id,
+            lambda x: x.date,
+            lambda x: x.sales,
+            as_column(
+                over(
+                    lambda x: sum(x.sales),  # Lambda expression with sum
+                    partition_by=lambda x: x.product_id,
+                    order_by=lambda x: x.date,
+                    frame=row(unbounded(), 0)  # ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+                ),
+                "running_total"
+            )
+        ).order_by(
+            lambda x: x.product_id,
+            lambda x: x.date
+        )
+        
+        # Generate SQL
+        sql = query.to_sql(dialect="duckdb")
+        expected_sql = "SELECT product_id, date, sales, SUM(sales) OVER (PARTITION BY product_id ORDER BY date ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS running_total\nFROM sales\nORDER BY product_id ASC, date ASC"
+        self.assertEqual(sql.strip(), expected_sql.strip())
+        
+        # Execute query
+        result = self.conn.execute(sql).fetchdf()
+        
+        # Verify result
+        self.assertEqual(len(result), 9)  # All sales records
+        
+        # Check running totals for product_id=1
+        product1_rows = result[result["product_id"] == 1].reset_index(drop=True)
+        self.assertEqual(product1_rows.loc[0, "running_total"], 100)
+        self.assertEqual(product1_rows.loc[1, "running_total"], 220)
+        self.assertEqual(product1_rows.loc[2, "running_total"], 350)
+        
+        # Check running totals for product_id=2
+        product2_rows = result[result["product_id"] == 2].reset_index(drop=True)
+        self.assertEqual(product2_rows.loc[0, "running_total"], 150)
+        self.assertEqual(product2_rows.loc[1, "running_total"], 310)
+        self.assertEqual(product2_rows.loc[2, "running_total"], 480)
+    
+    def test_moving_average_with_preceding_following(self):
+        """Test moving average with preceding and following rows."""
+        # Build query with moving average
+        query = self.df.select(
+            lambda x: x.product_id,
+            lambda x: x.date,
+            lambda x: x.sales,
+            as_column(
+                over(
+                    lambda x: avg(x.sales),  # Lambda expression with avg
+                    partition_by=lambda x: x.product_id,
+                    order_by=lambda x: x.date,
+                    frame=row(1, 1)  # ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING
+                ),
+                "moving_avg"
+            )
+        ).order_by(
+            lambda x: x.product_id,
+            lambda x: x.date
+        )
+        
+        # Generate SQL
+        sql = query.to_sql(dialect="duckdb")
+        expected_sql = "SELECT product_id, date, sales, AVG(sales) OVER (PARTITION BY product_id ORDER BY date ASC ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) AS moving_avg\nFROM sales\nORDER BY product_id ASC, date ASC"
+        self.assertEqual(sql.strip(), expected_sql.strip())
+        
+        # Execute query
+        result = self.conn.execute(sql).fetchdf()
+        
+        # Verify result
+        self.assertEqual(len(result), 9)  # All sales records
+        
+        # Check moving averages for product_id=1
+        product1_rows = result[result["product_id"] == 1].reset_index(drop=True)
+        self.assertAlmostEqual(product1_rows.loc[0, "moving_avg"], 110.0)  # Avg of [100, 120]
+        self.assertAlmostEqual(product1_rows.loc[1, "moving_avg"], 116.666667, places=5)  # Avg of [100, 120, 130]
+        self.assertAlmostEqual(product1_rows.loc[2, "moving_avg"], 125.0)  # Avg of [120, 130]
+    
+    def test_complex_expression_in_lambda(self):
+        """Test complex expression in lambda function."""
+        # Build query with complex lambda expression
+        query = self.df.select(
+            lambda x: x.product_id,
+            lambda x: x.region,
+            lambda x: x.sales,
+            as_column(
+                over(
+                    lambda x: sum(x.sales + 10),  # Complex expression: sales + 10
+                    partition_by=lambda x: x.region,
+                    frame=range(unbounded(), 0)  # RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+                ),
+                "adjusted_total"
+            )
+        ).order_by(
+            lambda x: x.region,
+            lambda x: x.product_id
+        )
+        
+        # Generate SQL
+        sql = query.to_sql(dialect="duckdb")
+        expected_sql = "SELECT product_id, region, sales, SUM((sales + 10)) OVER (PARTITION BY region RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS adjusted_total\nFROM sales\nORDER BY region ASC, product_id ASC"
+        self.assertEqual(sql.strip(), expected_sql.strip())
+        
+        # Execute query
+        result = self.conn.execute(sql).fetchdf()
+        
+        # Verify result
+        self.assertEqual(len(result), 9)  # All sales records
+        
+        # Check adjusted totals for East region
+        east_rows = result[result["region"] == "East"].reset_index(drop=True)
+        # Sum of (100+10, 120+10, 130+10, 150+10, 220+10) = 770
+        self.assertEqual(east_rows.loc[0, "adjusted_total"], 770.0)
+        
+        # Check adjusted totals for West region
+        west_rows = result[result["region"] == "West"].reset_index(drop=True)
+        # Sum of (160+10, 170+10, 200+10, 210+10) = 780
+        self.assertEqual(west_rows.loc[0, "adjusted_total"], 780.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cloud_dataframe/tests/integration/test_window_frames_duckdb.py
+++ b/cloud_dataframe/tests/integration/test_window_frames_duckdb.py
@@ -1,0 +1,189 @@
+"""
+Integration tests for window function frames with DuckDB.
+
+This module contains tests for using frame specifications with window functions
+using the cloud-dataframe library with DuckDB.
+"""
+import unittest
+import pandas as pd
+import duckdb
+from typing import Optional
+
+from cloud_dataframe.core.dataframe import DataFrame
+from cloud_dataframe.type_system.schema import TableSchema
+from cloud_dataframe.type_system.column import (
+    as_column, over, row_number, rank, dense_rank, sum,
+    row, range, unbounded
+)
+
+
+class TestWindowFramesDuckDB(unittest.TestCase):
+    """Test cases for window frames with DuckDB."""
+    
+    def setUp(self):
+        """Set up test fixtures."""
+        # Create a DuckDB connection
+        self.conn = duckdb.connect(":memory:")
+        
+        # Create test data for employees
+        employees_data = pd.DataFrame({
+            "id": [1, 2, 3, 4, 5, 6, 7, 8],
+            "name": ["Alice", "Bob", "Charlie", "David", "Eve", "Frank", "Grace", "Heidi"],
+            "department": ["Engineering", "Engineering", "Sales", "Sales", "Marketing", "Marketing", "HR", "HR"],
+            "salary": [80000.0, 90000.0, 70000.0, 75000.0, 65000.0, 60000.0, 55000.0, 58000.0],
+        })
+        
+        # Create the employees table in DuckDB
+        self.conn.execute("CREATE TABLE employees AS SELECT * FROM employees_data")
+        self.conn.register("employees_data", employees_data)
+        
+        # Create schema for the employees table
+        self.schema = TableSchema(
+            name="Employee",
+            columns={
+                "id": int,
+                "name": str,
+                "department": str,
+                "salary": float,
+            }
+        )
+        
+        # Create a DataFrame with typed properties
+        self.df = DataFrame.from_table_schema("employees", self.schema)
+    
+    def tearDown(self):
+        """Tear down test fixtures."""
+        self.conn.close()
+    
+    def test_sum_over_partition_with_frame(self):
+        """Test SUM with ROWS frame and partition by."""
+        # Build query with SUM window function and frame
+        query = self.df.select(
+            lambda x: x.id,
+            lambda x: x.name,
+            lambda x: x.department,
+            lambda x: x.salary,
+            as_column(
+                over(
+                    lambda x: sum(x.salary),
+                    partition_by=lambda x: x.department,
+                    frame=row(unbounded(), 0)  # unbounded preceding to current row
+                ),
+                "running_total"
+            )
+        ).order_by(
+            lambda x: x.department,
+            lambda x: x.salary
+        )
+        
+        # Generate SQL
+        sql = query.to_sql(dialect="duckdb")
+        
+        # Execute query
+        result = self.conn.execute(sql).fetchdf()
+        
+        # Verify result
+        self.assertEqual(len(result), 8)  # All employees
+        self.assertIn("running_total", result.columns)
+        
+        # Manual check for Engineering department running total
+        eng_rows = result[result["department"] == "Engineering"].reset_index(drop=True)
+        self.assertEqual(eng_rows.loc[0, "running_total"], eng_rows.loc[0, "salary"])
+        self.assertEqual(eng_rows.loc[1, "running_total"], eng_rows.loc[0, "salary"] + eng_rows.loc[1, "salary"])
+    
+    def test_moving_average_with_frame(self):
+        """Test moving average with ROWS frame."""
+        # Create a time series data
+        self.conn.execute("""
+            CREATE TABLE time_series AS
+            SELECT 
+                generate_series AS day,
+                (random() * 100)::INT AS value
+            FROM generate_series(1, 30, 1)
+        """)
+        
+        # Create schema for time series
+        ts_schema = TableSchema(
+            name="TimeSeries",
+            columns={
+                "day": int,
+                "value": int,
+            }
+        )
+        
+        # Create DataFrame
+        ts_df = DataFrame.from_table_schema("time_series", ts_schema)
+        
+        # Build query with moving average
+        from cloud_dataframe.type_system.column import row
+        query = ts_df.select(
+            lambda x: x.day,
+            lambda x: x.value,
+            as_column(
+                over(
+                    lambda x: sum(x.value),  # Lambda with sum function
+                    order_by=lambda x: x.day,
+                    frame=row(1, 1)  # 1 preceding, 1 following (3-day window)
+                ),
+                "moving_avg"
+            )
+        ).order_by(
+            lambda x: x.day
+        )
+        
+        # Generate SQL
+        sql = query.to_sql(dialect="duckdb")
+        
+        # Execute query
+        result = self.conn.execute(sql).fetchdf()
+        
+        # Verify result
+        self.assertEqual(len(result), 30)  # All days
+        self.assertIn("moving_avg", result.columns)
+        
+        # Verify middle values have 3 days in the average
+        middle_rows = result.iloc[1:-1]  # Skip first and last
+        for _, row in middle_rows.iterrows():
+            # Check if we're getting reasonable averages - values can be higher due to sum
+            self.assertGreaterEqual(row["moving_avg"], 0.0)
+            # We don't check upper bound since it's a sum of random values
+    
+    def test_lambda_function_with_complex_expression(self):
+        """Test lambda function with complex expression in over()."""
+        # Build query with complex lambda expression
+        query = self.df.select(
+            lambda x: x.id,
+            lambda x: x.name,
+            lambda x: x.department,
+            lambda x: x.salary,
+            as_column(
+                over(
+                    lambda x: sum(x.salary + 1000),  # Complex expression: salary + 1000
+                    partition_by=lambda x: x.department,
+                    frame=row(unbounded(), 0)
+                ),
+                "adjusted_total"
+            )
+        ).order_by(
+            lambda x: x.department,
+            lambda x: x.id
+        )
+        
+        # Generate SQL
+        sql = query.to_sql(dialect="duckdb")
+        
+        # Execute query
+        result = self.conn.execute(sql).fetchdf()
+        
+        # Verify result
+        self.assertEqual(len(result), 8)  # All employees
+        self.assertIn("adjusted_total", result.columns)
+        
+        # Check that the adjusted total includes the +1000 for each employee
+        eng_rows = result[result["department"] == "Engineering"].reset_index(drop=True)
+        expected_total = (eng_rows.loc[0, "salary"] + 1000) + (eng_rows.loc[1, "salary"] + 1000)
+        self.assertEqual(eng_rows.loc[1, "adjusted_total"], expected_total)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cloud_dataframe/tests/unit/test_window_frames.py
+++ b/cloud_dataframe/tests/unit/test_window_frames.py
@@ -1,0 +1,185 @@
+"""
+Unit tests for window functions with frame specifications.
+
+This module contains tests for using frame specifications with window functions.
+"""
+import unittest
+from typing import Optional
+
+from cloud_dataframe.core.dataframe import DataFrame
+from cloud_dataframe.type_system.schema import TableSchema
+from cloud_dataframe.type_system.column import (
+    as_column, col, over, row_number, rank, dense_rank,
+    row, range, unbounded
+)
+
+
+class TestWindowFrames(unittest.TestCase):
+    """Test cases for window functions with frame specifications."""
+    
+    def setUp(self):
+        """Set up test fixtures."""
+        self.schema = TableSchema(
+            name="Employee",
+            columns={
+                "id": int,
+                "name": str,
+                "department": str,
+                "salary": float,
+            }
+        )
+        
+        # Create a DataFrame with typed properties
+        self.df = DataFrame.from_table_schema("employees", self.schema)
+    
+    def test_row_frame_current_preceding(self):
+        """Test ROWS frame with current row to preceding rows."""
+        df_with_frame = self.df.select(
+            lambda x: x.id,
+            lambda x: x.salary,
+            as_column(
+                over(
+                    row_number(),
+                    partition_by=lambda x: x.department,
+                    order_by=lambda x: x.salary,
+                    frame=row(2, 0)  # 2 preceding to current row
+                ),
+                "row_num"
+            )
+        )
+        
+        # Check the SQL generation
+        sql = df_with_frame.to_sql(dialect="duckdb")
+        expected_sql = "SELECT id, salary, ROW_NUMBER() OVER (PARTITION BY department ORDER BY salary ASC ROWS BETWEEN 2 PRECEDING AND CURRENT ROW) AS row_num\nFROM employees"
+        self.assertEqual(sql.strip(), expected_sql.strip())
+    
+    def test_row_frame_preceding_following(self):
+        """Test ROWS frame with preceding to following rows."""
+        df_with_frame = self.df.select(
+            lambda x: x.id,
+            lambda x: x.salary,
+            as_column(
+                over(
+                    rank(),
+                    partition_by=lambda x: x.department,
+                    order_by=lambda x: x.salary,
+                    frame=row(2, 2)  # 2 preceding to 2 following
+                ),
+                "rank_val"
+            )
+        )
+        
+        # Check the SQL generation
+        sql = df_with_frame.to_sql(dialect="duckdb")
+        expected_sql = "SELECT id, salary, RANK() OVER (PARTITION BY department ORDER BY salary ASC ROWS BETWEEN 2 PRECEDING AND 2 FOLLOWING) AS rank_val\nFROM employees"
+        self.assertEqual(sql.strip(), expected_sql.strip())
+    
+    def test_row_frame_current_following(self):
+        """Test ROWS frame with current row to following rows."""
+        df_with_frame = self.df.select(
+            lambda x: x.id,
+            lambda x: x.salary,
+            as_column(
+                over(
+                    dense_rank(),
+                    partition_by=lambda x: x.department,
+                    order_by=lambda x: x.salary,
+                    frame=row(0, 2)  # current row to 2 following
+                ),
+                "dense_rank_val"
+            )
+        )
+        
+        # Check the SQL generation
+        sql = df_with_frame.to_sql(dialect="duckdb")
+        expected_sql = "SELECT id, salary, DENSE_RANK() OVER (PARTITION BY department ORDER BY salary ASC ROWS BETWEEN CURRENT ROW AND 2 FOLLOWING) AS dense_rank_val\nFROM employees"
+        self.assertEqual(sql.strip(), expected_sql.strip())
+    
+    def test_row_frame_unbounded_preceding(self):
+        """Test ROWS frame with unbounded preceding to current row."""
+        df_with_frame = self.df.select(
+            lambda x: x.id,
+            lambda x: x.salary,
+            as_column(
+                over(
+                    row_number(),
+                    partition_by=lambda x: x.department,
+                    order_by=lambda x: x.salary,
+                    frame=row(unbounded(), 0)  # unbounded preceding to current row
+                ),
+                "row_num"
+            )
+        )
+        
+        # Check the SQL generation
+        sql = df_with_frame.to_sql(dialect="duckdb")
+        expected_sql = "SELECT id, salary, ROW_NUMBER() OVER (PARTITION BY department ORDER BY salary ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS row_num\nFROM employees"
+        self.assertEqual(sql.strip(), expected_sql.strip())
+    
+    def test_row_frame_preceding_unbounded(self):
+        """Test ROWS frame with preceding to unbounded following."""
+        df_with_frame = self.df.select(
+            lambda x: x.id,
+            lambda x: x.salary,
+            as_column(
+                over(
+                    rank(),
+                    partition_by=lambda x: x.department,
+                    order_by=lambda x: x.salary,
+                    frame=row(2, unbounded())  # 2 preceding to unbounded following
+                ),
+                "rank_val"
+            )
+        )
+        
+        # Check the SQL generation
+        sql = df_with_frame.to_sql(dialect="duckdb")
+        expected_sql = "SELECT id, salary, RANK() OVER (PARTITION BY department ORDER BY salary ASC ROWS BETWEEN 2 PRECEDING AND UNBOUNDED FOLLOWING) AS rank_val\nFROM employees"
+        self.assertEqual(sql.strip(), expected_sql.strip())
+    
+    def test_range_frame(self):
+        """Test RANGE frame specification."""
+        df_with_frame = self.df.select(
+            lambda x: x.id,
+            lambda x: x.salary,
+            as_column(
+                over(
+                    dense_rank(),
+                    partition_by=lambda x: x.department,
+                    order_by=lambda x: x.salary,
+                    frame=range(unbounded(), 0)  # unbounded preceding to current row
+                ),
+                "dense_rank_val"
+            )
+        )
+        
+        # Check the SQL generation
+        sql = df_with_frame.to_sql(dialect="duckdb")
+        expected_sql = "SELECT id, salary, DENSE_RANK() OVER (PARTITION BY department ORDER BY salary ASC RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS dense_rank_val\nFROM employees"
+        self.assertEqual(sql.strip(), expected_sql.strip())
+
+    def test_lambda_function_over(self):
+        """Test lambda function expression in over()."""
+        from cloud_dataframe.type_system.column import sum
+        
+        df_with_lambda = self.df.select(
+            lambda x: x.id,
+            lambda x: x.salary,
+            as_column(
+                over(
+                    lambda x: sum(x.salary),
+                    partition_by=lambda x: x.department,
+                    frame=row(unbounded(), 0)
+                ),
+                "sum_salary"
+            )
+        )
+        
+        # Check the SQL generation
+        sql = df_with_lambda.to_sql(dialect="duckdb")
+        expected_sql = "SELECT id, salary, SUM(salary) OVER (PARTITION BY department ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS sum_salary\nFROM employees"
+        self.assertEqual(sql.strip(), expected_sql.strip())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR enhances the window functionality in the cloud-dataframe library with two features:

1. Extended the "over" function to accept lambda function expressions, allowing SQL functions to work with expressions like `lambda x: first(x.col1 + x.col2)`
2. Added frame type to the DSL and a frame parameter to the "over" function to support `row()` and `range()` frame specifications with framestart and frameend

Link to Devin run: https://app.devin.ai/sessions/d57895cfa95c48fc86ed1b5d6fce7160
Requested by: neema.raphael@gs.com