### PR TITLE
Remove string-based ASC/DESC support in order_by

### DIFF
--- a/cloud_dataframe/backends/duckdb/sql_generator.py
+++ b/cloud_dataframe/backends/duckdb/sql_generator.py
@@ -360,7 +360,12 @@ def _generate_window_function(func: WindowFunction) -> str:
         for clause in func.window.order_by:
             if isinstance(clause, OrderByClause):
                 expr_sql = _generate_expression(clause.expression)
-                direction_sql = clause.direction.value
+                # Only handle SortDirection enum values
+                if hasattr(clause.direction, 'value'):
+                    direction_sql = clause.direction.value
+                else:
+                    # This should not happen with the updated code, but handle it gracefully
+                    raise ValueError(f"Invalid sort direction: {clause.direction}. Must use SortDirection enum.")
                 order_by_parts.append(f"{expr_sql} {direction_sql}")
             else:
                 # For backward compatibility with non-OrderByClause objects
@@ -580,12 +585,12 @@ def _generate_order_by(df: DataFrame) -> str:
     for clause in df.order_by_clauses:
         if isinstance(clause, OrderByClause):
             expr_sql = _generate_expression(clause.expression)
-            # Handle both SortDirection enum and string values
+            # Only handle SortDirection enum values
             if hasattr(clause.direction, 'value'):
                 direction_sql = clause.direction.value
             else:
-                # Default to ASC if direction is not a SortDirection enum
-                direction_sql = "ASC"
+                # This should not happen with the updated code, but handle it gracefully
+                raise ValueError(f"Invalid sort direction: {clause.direction}. Must use SortDirection enum.")
             order_by_parts.append(f"{expr_sql} {direction_sql}")
         else:
             # For backward compatibility with non-OrderByClause objects

--- a/cloud_dataframe/core/dataframe.py
+++ b/cloud_dataframe/core/dataframe.py
@@ -369,7 +369,7 @@ class DataFrame:
                 - Lambda functions that access dataclass properties (e.g., lambda x: x.column_name)
                 - Lambda functions that return arrays (e.g., lambda x: [x.department, x.salary])
                 - Lambda functions that return tuples with sort direction (e.g., lambda x: 
-                  [(x.department, 'DESC'), (x.salary, 'ASC'), x.name])
+                  [(x.department, SortDirection.DESC), (x.salary, SortDirection.ASC), x.name])
             desc: Whether to sort in descending order (if not using OrderByClause or tuple specification)
             
         Returns:
@@ -396,9 +396,10 @@ class DataFrame:
                         # Check if the expression is a tuple with a sort direction
                         if isinstance(single_expr, tuple) and len(single_expr) == 2:
                             col_expr, sort_dir = single_expr
-                            # Convert string sort direction to SortDirection enum
-                            if isinstance(sort_dir, str):
-                                sort_dir = SortDirection.DESC if sort_dir.upper() == 'DESC' else SortDirection.ASC
+                            # Only accept SortDirection enum values, not strings
+                            if not isinstance(sort_dir, SortDirection):
+                                raise ValueError(f"Sort direction must be a SortDirection enum value, not {type(sort_dir).__name__}. "
+                                               f"Use SortDirection.ASC or SortDirection.DESC instead of strings.")
                             
                             # Skip if we've already added this column
                             if isinstance(col_expr, ColumnReference) and col_expr.name in added_columns:

--- a/cloud_dataframe/examples/comprehensive_example.py
+++ b/cloud_dataframe/examples/comprehensive_example.py
@@ -8,7 +8,7 @@ import duckdb
 from dataclasses import dataclass
 from typing import Optional
 
-from cloud_dataframe.core.dataframe import DataFrame
+from cloud_dataframe.core.dataframe import DataFrame, SortDirection
 from cloud_dataframe.type_system.schema import TableSchema
 from cloud_dataframe.type_system.column import (
     as_column, col, literal,
@@ -215,7 +215,7 @@ def comprehensive_query_with_array_lambdas():
             over(
                 row_number(),
                 partition_by=lambda x: x.e.department,
-                order_by=lambda x: [(x.e.salary, 'DESC')]  # Salary in descending order
+                order_by=lambda x: [(x.e.salary, SortDirection.DESC)]  # Salary in descending order
             ),
             "salary_rank_in_dept"
         ),
@@ -224,7 +224,7 @@ def comprehensive_query_with_array_lambdas():
             over(
                 rank(),
                 partition_by=lambda x: [x.e.department, x.e.location],
-                order_by=lambda x: [(x.e.salary, 'ASC'), (x.e.id, 'DESC')]  # Salary ASC, ID DESC
+                order_by=lambda x: [(x.e.salary, SortDirection.ASC), (x.e.id, SortDirection.DESC)]  # Salary ASC, ID DESC
             ),
             "salary_rank_with_ties"
         ),
@@ -233,7 +233,7 @@ def comprehensive_query_with_array_lambdas():
             over(
                 dense_rank(),
                 partition_by=lambda x: x.e.department,
-                order_by=lambda x: [(x.e.salary, 'DESC'), (x.e.id, 'ASC')]  # Salary DESC, ID ASC
+                order_by=lambda x: [(x.e.salary, SortDirection.DESC), (x.e.id, SortDirection.ASC)]  # Salary DESC, ID ASC
             ),
             "dense_salary_rank"
         )

--- a/cloud_dataframe/tests/integration/test_window_examples.py
+++ b/cloud_dataframe/tests/integration/test_window_examples.py
@@ -9,7 +9,7 @@ import pandas as pd
 import duckdb
 from typing import Optional, Dict
 
-from cloud_dataframe.core.dataframe import DataFrame
+from cloud_dataframe.core.dataframe import DataFrame, SortDirection
 from cloud_dataframe.type_system.schema import TableSchema
 from cloud_dataframe.type_system.column import as_column, sum, avg, count, rank, dense_rank, row_number, over
 
@@ -63,7 +63,7 @@ class TestWindowExamples(unittest.TestCase):
             lambda x: x.department,
             lambda x: x.salary,
             as_column(
-                over(rank(), partition_by=lambda x: x.department, order_by=lambda x: [(x.salary, 'DESC')]),
+                over(rank(), partition_by=lambda x: x.department, order_by=lambda x: [(x.salary, SortDirection.DESC)]),
                 "salary_rank"
             )
         )
@@ -101,7 +101,7 @@ class TestWindowExamples(unittest.TestCase):
             lambda x: x.department,
             lambda x: x.salary,
             as_column(
-                over(row_number(), partition_by=lambda x: x.department, order_by=lambda x: [(x.salary, 'DESC')]),
+                over(row_number(), partition_by=lambda x: x.department, order_by=lambda x: [(x.salary, SortDirection.DESC)]),
                 "row_num"
             )
         )
@@ -140,7 +140,7 @@ class TestWindowExamples(unittest.TestCase):
             lambda x: x.department,
             lambda x: x.salary,
             as_column(
-                over(rank(), partition_by=lambda x: x.department, order_by=lambda x: [(x.salary, 'DESC')]),
+                over(rank(), partition_by=lambda x: x.department, order_by=lambda x: [(x.salary, SortDirection.DESC)]),
                 "salary_rank"
             )
         )
@@ -188,15 +188,15 @@ class TestWindowExamples(unittest.TestCase):
             lambda x: x.department,
             lambda x: x.salary,
             as_column(
-                over(rank(), partition_by=lambda x: x.department, order_by=lambda x: [(x.salary, 'DESC')]),
+                over(rank(), partition_by=lambda x: x.department, order_by=lambda x: [(x.salary, SortDirection.DESC)]),
                 "salary_rank"
             ),
             as_column(
-                over(dense_rank(), partition_by=lambda x: x.department, order_by=lambda x: [(x.salary, 'DESC')]),
+                over(dense_rank(), partition_by=lambda x: x.department, order_by=lambda x: [(x.salary, SortDirection.DESC)]),
                 "dense_rank"
             ),
             as_column(
-                over(row_number(), partition_by=lambda x: x.department, order_by=lambda x: [(x.salary, 'DESC')]),
+                over(row_number(), partition_by=lambda x: x.department, order_by=lambda x: [(x.salary, SortDirection.DESC)]),
                 "row_num"
             )
         )

--- a/cloud_dataframe/type_system/column.py
+++ b/cloud_dataframe/type_system/column.py
@@ -437,7 +437,7 @@ def over(func: Union[WindowFunction, Callable],
             Can be a lambda that returns:
             - A single column reference (lambda x: x.column)
             - A list of column references (lambda x: [x.col1, x.col2])
-            - A list with tuples specifying sort direction (lambda x: [(x.col1, 'DESC'), (x.col2, 'ASC')])
+            - A list with tuples specifying sort direction (lambda x: [(x.col1, SortDirection.DESC), (x.col2, SortDirection.ASC)])
         frame: Optional frame specification created with row() or range() functions
         
     Returns:

--- a/cloud_dataframe/utils/lambda_parser.py
+++ b/cloud_dataframe/utils/lambda_parser.py
@@ -25,7 +25,7 @@ def parse_lambda(lambda_func: Callable, table_schema=None) -> Union[Expression, 
             - A lambda that returns a boolean expression (e.g., lambda x: x.age > 30)
             - A lambda that returns a column reference (e.g., lambda x: x.name)
             - A lambda that returns an array of column references (e.g., lambda x: [x.name, x.age])
-            - A lambda that returns tuples with sort direction (e.g., lambda x: [(x.department, 'DESC')])
+            - A lambda that returns tuples with sort direction (e.g., lambda x: [(x.department, SortDirection.DESC)])
         table_schema: Optional schema for type checking
         
     Returns:
@@ -53,7 +53,7 @@ class LambdaParser:
                 - A lambda that returns a boolean expression (e.g., lambda x: x.age > 30)
                 - A lambda that returns a column reference (e.g., lambda x: x.name)
                 - A lambda that returns an array of column references (e.g., lambda x: [x.name, x.age])
-                - A lambda that returns tuples with sort direction (e.g., lambda x: [(x.department, 'DESC')])
+                - A lambda that returns tuples with sort direction (e.g., lambda x: [(x.department, SortDirection.DESC)])
             table_schema: Optional schema for type checking
             
         Returns:
@@ -238,6 +238,9 @@ class LambdaParser:
             An Expression or list of Expressions representing the AST node,
             or list containing tuples of (Expression, sort_direction) for order_by clauses
         """
+        # Import needed classes
+        from ..type_system.column import LiteralExpression
+        from ..core.dataframe import SortDirection
         # Handle different types of AST nodes
         if isinstance(node, ast.Compare):
             # Handle comparison operations (e.g., x > 5, y == 'value')
@@ -532,15 +535,17 @@ class LambdaParser:
                     col_expr = LambdaParser._parse_expression(elt.elts[0], args, table_schema)
                     sort_dir = LambdaParser._parse_expression(elt.elts[1], args, table_schema)
                     
-                    # Handle both string literals and SortDirection enum references
-                    if isinstance(sort_dir, LiteralExpression):
-                        # String literal like 'DESC'
-                        elements.append((col_expr, sort_dir.value))
-                    elif isinstance(elt.elts[1], ast.Attribute) and elt.elts[1].attr in ('DESC', 'ASC'):
+                    # Handle SortDirection enum references
+                    if isinstance(elt.elts[1], ast.Attribute) and elt.elts[1].attr in ('DESC', 'ASC'):
                         # SortDirection enum reference like SortDirection.DESC
-                        elements.append((col_expr, elt.elts[1].attr))
+                        from ..core.dataframe import SortDirection
+                        sort_direction = SortDirection.DESC if elt.elts[1].attr == 'DESC' else SortDirection.ASC
+                        elements.append((col_expr, sort_direction))
+                    elif isinstance(sort_dir, LiteralExpression):
+                        # Convert string literals to SortDirection enum
+                        raise ValueError(f"String literals for sort direction ('{sort_dir.value}') are no longer supported. Use SortDirection.DESC or SortDirection.ASC instead.")
                     else:
-                        # Other cases
+                        # Other cases - pass through the sort_dir as is
                         elements.append((col_expr, sort_dir))
                 else:
                     elements.append(LambdaParser._parse_expression(elt, args, table_schema))


### PR DESCRIPTION
This PR removes the ability for order_by to take string literals for ASC/DESC and requires using SortDirection enum instead.

Changes:
- Modified DataFrame.order_by method to reject string literals
- Updated SQL generator to handle SortDirection enum values
- Updated lambda parser to raise error for string literals
- Updated all tests and examples to use SortDirection enum

Link to Devin run: https://app.devin.ai/sessions/d57895cfa95c48fc86ed1b5d6fce7160
Requested by: Neema Raphael