### PR TITLE
Fix ColumnReference to support table_name parameter

### DIFF
--- a/cloud_dataframe/type_system/column.py
+++ b/cloud_dataframe/type_system/column.py
@@ -41,6 +41,7 @@ class ColumnReference(Expression):
     """Reference to a column in a table."""
     name: str
     table_alias: Optional[str] = None
+    table_name: Optional[str] = None
 
 
 @dataclass
@@ -177,18 +178,19 @@ class Column:
 
 # Helper functions for creating expressions
 
-def col(name: str, table_alias: Optional[str] = None) -> ColumnReference:
+def col(name: str, table_alias: Optional[str] = None, table_name: Optional[str] = None) -> ColumnReference:
     """
     Create a column reference.
     
     Args:
         name: The name of the column
         table_alias: Optional table alias
+        table_name: Optional table name
         
     Returns:
         A ColumnReference expression
     """
-    return ColumnReference(name=name, table_alias=table_alias)
+    return ColumnReference(name=name, table_alias=table_alias, table_name=table_name)
 
 
 def literal(value: Any) -> LiteralExpression:


### PR DESCRIPTION
Added table_name parameter to ColumnReference class to fix failing tests in test_sql_generation_duckdb.py. Tests test_select_with_join_and_where and test_select_with_join_where_and_group_by were failing due to this missing parameter.

Link to Devin run: https://app.devin.ai/sessions/7613de2e2a1f4e25bdebc32978e904bd
Requested by: neema.raphael@gs.com