### PR TITLE
Update column aliasing in test_join_examples.py to use walrus operator

### DIFF
--- a/cloud_dataframe/tests/integration/test_join_examples.py
+++ b/cloud_dataframe/tests/integration/test_join_examples.py
@@ -78,11 +78,11 @@ class TestJoinExamples(unittest.TestCase):
             self.departments_df,
             lambda e, d: e.department_id == d.id
         ).select(
-            lambda e: e.id.alias("employee_id"),
-            lambda e: e.name.alias("employee_name"),
-            lambda d: d.name.alias("department_name"),
-            lambda d: d.location.alias("department_location"),
-            lambda e: e.salary.alias("employee_salary")
+            lambda e: (employee_id := e.id),
+            lambda e: (employee_name := e.name),
+            lambda d: (department_name := d.name),
+            lambda d: (department_location := d.location),
+            lambda e: (employee_salary := e.salary)
         )
         
         # Generate SQL
@@ -117,7 +117,7 @@ class TestJoinExamples(unittest.TestCase):
         ).select(
             lambda e: e.id,
             lambda e: e.name,
-            lambda d: d.name.alias("department_name"),
+            lambda d: (department_name := d.name),
             lambda d: d.location,
             lambda e: e.salary
         )
@@ -145,10 +145,10 @@ class TestJoinExamples(unittest.TestCase):
         ).group_by(
             lambda d: d.name
         ).select(
-            lambda d: d.name.alias("department_name"),
-            as_column(lambda e: count(e.id.alias("employee_id")), "employee_count"),
-            as_column(lambda e: sum(e.salary.alias("employee_salary")), "total_salary"),
-            as_column(lambda e: avg(e.salary.alias("employee_salary")), "avg_salary")
+            lambda d: (department_name := d.name),
+            as_column(count(lambda e: e.id), "employee_count"),
+            as_column(sum(lambda e: e.salary), "total_salary"),
+            as_column(avg(lambda e: e.salary), "avg_salary")
         ).order_by(
             lambda d: d.name
         )


### PR DESCRIPTION
This PR updates test_join_examples.py to use the walrus operator (:=) for column aliasing instead of the .alias() method.

Key improvements:
- Updated column aliasing in test_inner_join
- Updated column aliasing in test_left_join
- Updated aggregate function calls in test_join_with_aggregation

Link to Devin run: https://app.devin.ai/sessions/41ce539d37e74a229afaa99210e49e3a
Requested by: Neema Raphael