### PR TITLE
Fix GROUP BY clause in test_array_lambda.py

### DIFF
--- a/cloud_dataframe/tests/unit/test_array_lambda.py
+++ b/cloud_dataframe/tests/unit/test_array_lambda.py
@@ -56,7 +56,7 @@ class TestArrayLambda(unittest.TestCase):
         
         # Check the SQL generation
         sql = grouped_df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT x.department, x.location, AVG(x.salary) AS avg_salary\nFROM employees x\nGROUP BY x.department"
+        expected_sql = "SELECT x.department, x.location, AVG(x.salary) AS avg_salary\nFROM employees x\nGROUP BY x.department, x.location"
         self.assertEqual(sql.strip(), expected_sql.strip())
     
     def test_order_by_with_array_lambda(self):


### PR DESCRIPTION
This PR fixes the GROUP BY clause in test_array_lambda.py to include all grouped columns.

Key improvements:
- Corrected expected SQL in test_group_by_with_array_lambda to include both department and location columns in GROUP BY clause
- Ensures test correctly validates array lambda functionality

Link to Devin run: https://app.devin.ai/sessions/41ce539d37e74a229afaa99210e49e3a
Requested by: Neema Raphael