### PR TITLE
Update test_sql_generation.py with consistent table alias usage

### DIFF
--- a/cloud_dataframe/tests/integration/test_sql_generation.py
+++ b/cloud_dataframe/tests/integration/test_sql_generation.py
@@ -49,13 +49,13 @@ class TestDuckDBSQLGeneration(unittest.TestCase):
     
     def test_select_columns(self):
         """Test generating SQL for a SELECT query with specific columns."""
-        df = DataFrame.from_("employees", alias="x").select(
-            as_column(col("id"), "id"),
-            as_column(col("name"), "name")
+        df = DataFrame.from_("employees", alias="e").select(
+            lambda e: (id := e.id),
+            lambda e: (name := e.name)
         )
         
         sql = df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT x.id AS id, x.name AS name\nFROM employees x"
+        expected_sql = "SELECT e.id AS id, e.name AS name\nFROM employees e"
         self.assertEqual(sql.strip(), expected_sql)
     
     def test_filter(self):


### PR DESCRIPTION
This PR updates test_sql_generation.py to ensure consistent table alias usage and modern syntax.

Key improvements:
- Updated test_select_columns to use walrus operator for column aliasing
- Changed table alias from "x" to "e" for better readability
- Updated expected SQL to match the new table alias

Link to Devin run: https://app.devin.ai/sessions/41ce539d37e74a229afaa99210e49e3a
Requested by: Neema Raphael