### PR TITLE
Fix TestComplexFilterConditions.test_chained_filters by using consistent alias

### DIFF
--- a/cloud_dataframe/tests/integration/test_complex_filters.py
+++ b/cloud_dataframe/tests/integration/test_complex_filters.py
@@ -141,8 +141,8 @@ class TestComplexFilterConditions(unittest.TestCase):
     
     def test_chained_filters(self):
         """Test chaining multiple filters."""
-        df = DataFrame.from_("employees", alias="x").filter(
-            lambda x: (x.salary > 50000) and (x.department == "Engineering") and (x.age > 30)
+        df = DataFrame.from_("employees", alias="e").filter(
+            lambda e: (e.salary > 50000) and (e.department == "Engineering") and (e.age > 30)
         )
         
         sql = df.to_sql(dialect="duckdb")


### PR DESCRIPTION
This PR fixes the TestComplexFilterConditions.test_chained_filters test by changing the alias from "x" to "e" to match the expected SQL in the test assertion.

**Changes made:**
- Modified the DataFrame creation to use alias "e" instead of "x"
- Updated the lambda parameter to use "e" instead of "x"

The test now passes successfully.

Link to Devin run: https://app.devin.ai/sessions/4fe9a757442f40b68ee2145b10366ef4
Requested by: Neema Raphael