### PR TITLE
Add window() function parsing to lambda_parser with optional arguments

### DIFF
--- a/cloud_dataframe/tests/integration/test_window_function_parsing.py
+++ b/cloud_dataframe/tests/integration/test_window_function_parsing.py
@@ -1,0 +1,155 @@
+"""
+Integration tests for window() function parsing with DuckDB.
+
+This module contains tests for using the window() function in queries
+executed on a real DuckDB database.
+"""
+import unittest
+import pandas as pd
+import duckdb
+from typing import Optional
+
+from cloud_dataframe.core.dataframe import DataFrame, OrderByClause, Sort
+from cloud_dataframe.type_system.schema import TableSchema
+from cloud_dataframe.type_system.column import (
+    as_column, sum, rank, window, row, unbounded, ColumnReference
+)
+
+
+class TestWindowFunctionParsing(unittest.TestCase):
+    """Test cases for window() function parsing with DuckDB."""
+    
+    def setUp(self):
+        """Set up test fixtures."""
+        self.conn = duckdb.connect(":memory:")
+        
+        employees_data = pd.DataFrame({
+            "id": [1, 2, 3, 4, 5, 6],
+            "name": ["Alice", "Bob", "Charlie", "David", "Eve", "Frank"],
+            "department": ["Engineering", "Engineering", "Sales", "Sales", "Marketing", "Marketing"],
+            "salary": [80000.0, 90000.0, 70000.0, 75000.0, 65000.0, 60000.0],
+        })
+        
+        self.conn.execute("CREATE TABLE employees AS SELECT * FROM employees_data")
+        self.conn.register("employees_data", employees_data)
+        
+        self.schema = TableSchema(
+            name="Employee",
+            columns={
+                "id": int,
+                "name": str,
+                "department": str,
+                "salary": float,
+            }
+        )
+        
+        self.df = DataFrame.from_table_schema("employees", self.schema)
+    
+    def tearDown(self):
+        """Tear down test fixtures."""
+        self.conn.close()
+    
+    def test_window_with_rank(self):
+        """Test window() function with rank() function."""
+        query = self.df.select(
+            lambda x: x.id,
+            lambda x: x.name,
+            lambda x: x.department,
+            lambda x: x.salary,
+            as_column(lambda x: window(func=rank(), partition=x.department, order_by=x.salary), "salary_rank")
+        )
+        
+        sql = query.to_sql(dialect="duckdb")
+        
+        result = self.conn.execute(sql).fetchdf()
+        
+        self.assertEqual(len(result), 6)  # All employees
+        self.assertIn("salary_rank", result.columns)
+        
+        departments = result["department"].unique()
+        for dept in departments:
+            dept_rows = result[result["department"] == dept].sort_values("salary_rank").reset_index(drop=True)
+            self.assertEqual(dept_rows.iloc[0]["salary_rank"], 1)
+    
+    def test_window_with_frame(self):
+        """Test window() function with frame specification."""
+        query = self.df.select(
+            lambda x: x.id,
+            lambda x: x.name,
+            lambda x: x.department,
+            lambda x: x.salary,
+            as_column(
+                lambda x: window(
+                    func=sum(x.salary),
+                    partition=x.department,
+                    order_by=x.salary,
+                    frame=row(unbounded(), 0)
+                ),
+                "running_sum"
+            )
+        )
+        
+        sql = query.to_sql(dialect="duckdb")
+        
+        result = self.conn.execute(sql).fetchdf()
+        
+        self.assertEqual(len(result), 6)  # All employees
+        self.assertIn("running_sum", result.columns)
+        
+        departments = result["department"].unique()
+        for dept in departments:
+            dept_rows = result[result["department"] == dept].sort_values("salary").reset_index(drop=True)
+            dept_salaries = dept_rows["salary"].tolist()
+            
+            expected_sums = []
+            running_total = 0
+            for salary in dept_salaries:
+                running_total += salary
+                expected_sums.append(running_total)
+            
+            actual_sums = dept_rows["running_sum"].tolist()
+            for i in range(len(expected_sums)):
+                self.assertAlmostEqual(actual_sums[i], expected_sums[i], places=2)
+    
+    def test_window_with_multiple_functions(self):
+        """Test multiple window functions in a single query."""
+        query = self.df.select(
+            lambda x: x.id,
+            lambda x: x.name,
+            lambda x: x.department,
+            lambda x: x.salary,
+            as_column(
+                lambda x: window(
+                    func=rank(),
+                    partition=x.department,
+                    order_by=x.salary
+                ),
+                "salary_rank"
+            ),
+            as_column(
+                lambda x: window(
+                    func=sum(x.salary),
+                    partition=x.department,
+                    order_by=x.salary,
+                    frame=row(unbounded(), 0)
+                ),
+                "running_sum"
+            )
+        )
+        
+        sql = query.to_sql(dialect="duckdb")
+        
+        result = self.conn.execute(sql).fetchdf()
+        
+        self.assertEqual(len(result), 6)  # All employees
+        self.assertIn("salary_rank", result.columns)
+        self.assertIn("running_sum", result.columns)
+        
+        departments = result["department"].unique()
+        for dept in departments:
+            dept_rows = result[result["department"] == dept].sort_values("salary_rank").reset_index(drop=True)
+            self.assertEqual(dept_rows.iloc[0]["salary_rank"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cloud_dataframe/tests/integration/test_window_sql.py
+++ b/cloud_dataframe/tests/integration/test_window_sql.py
@@ -1,0 +1,122 @@
+"""
+Integration tests for window functions using direct SQL with DuckDB.
+
+This module contains tests for window functions executed on a real DuckDB database
+using direct SQL queries. These tests verify that the window function syntax works
+correctly with DuckDB before implementing the DSL parsing.
+"""
+import unittest
+import pandas as pd
+import duckdb
+
+
+class TestWindowSQL(unittest.TestCase):
+    """Test cases for window functions using direct SQL with DuckDB."""
+    
+    def setUp(self):
+        """Set up test fixtures."""
+        self.conn = duckdb.connect(":memory:")
+        
+        employees_data = pd.DataFrame({
+            "id": [1, 2, 3, 4, 5, 6],
+            "name": ["Alice", "Bob", "Charlie", "David", "Eve", "Frank"],
+            "department": ["Engineering", "Engineering", "Sales", "Sales", "Marketing", "Marketing"],
+            "salary": [80000.0, 90000.0, 70000.0, 75000.0, 65000.0, 60000.0],
+        })
+        
+        self.conn.execute("CREATE TABLE employees AS SELECT * FROM employees_data")
+        self.conn.register("employees_data", employees_data)
+    
+    def tearDown(self):
+        """Tear down test fixtures."""
+        self.conn.close()
+    
+    def test_window_with_rank(self):
+        """Test window function with rank() function."""
+        sql = """
+        SELECT 
+            id, 
+            name, 
+            department, 
+            salary,
+            RANK() OVER (PARTITION BY department ORDER BY salary) AS salary_rank
+        FROM employees
+        """
+        
+        result = self.conn.execute(sql).fetchdf()
+        
+        self.assertEqual(len(result), 6)  # All employees
+        self.assertIn("salary_rank", result.columns)
+        
+        departments = result["department"].unique()
+        for dept in departments:
+            dept_rows = result[result["department"] == dept].sort_values("salary_rank").reset_index(drop=True)
+            self.assertEqual(dept_rows.iloc[0]["salary_rank"], 1)
+    
+    def test_window_with_frame(self):
+        """Test window function with frame specification."""
+        sql = """
+        SELECT 
+            id, 
+            name, 
+            department, 
+            salary,
+            SUM(salary) OVER (
+                PARTITION BY department 
+                ORDER BY salary 
+                ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+            ) AS running_sum
+        FROM employees
+        """
+        
+        result = self.conn.execute(sql).fetchdf()
+        
+        self.assertEqual(len(result), 6)  # All employees
+        self.assertIn("running_sum", result.columns)
+        
+        departments = result["department"].unique()
+        for dept in departments:
+            dept_rows = result[result["department"] == dept].sort_values("salary").reset_index(drop=True)
+            dept_salaries = dept_rows["salary"].tolist()
+            
+            expected_sums = []
+            running_total = 0
+            for salary in dept_salaries:
+                running_total += salary
+                expected_sums.append(running_total)
+            
+            actual_sums = dept_rows["running_sum"].tolist()
+            for i in range(len(expected_sums)):
+                self.assertAlmostEqual(actual_sums[i], expected_sums[i], places=2)
+    
+    def test_window_with_multiple_functions(self):
+        """Test multiple window functions in a single query."""
+        sql = """
+        SELECT 
+            id, 
+            name, 
+            department, 
+            salary,
+            RANK() OVER (PARTITION BY department ORDER BY salary) AS salary_rank,
+            SUM(salary) OVER (
+                PARTITION BY department 
+                ORDER BY salary 
+                ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+            ) AS running_sum
+        FROM employees
+        """
+        
+        result = self.conn.execute(sql).fetchdf()
+        
+        self.assertEqual(len(result), 6)  # All employees
+        self.assertIn("salary_rank", result.columns)
+        self.assertIn("running_sum", result.columns)
+        
+        departments = result["department"].unique()
+        for dept in departments:
+            dept_rows = result[result["department"] == dept].sort_values("salary_rank").reset_index(drop=True)
+            self.assertEqual(dept_rows.iloc[0]["salary_rank"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cloud_dataframe/tests/unit/test_window_function.py
+++ b/cloud_dataframe/tests/unit/test_window_function.py
@@ -1,0 +1,214 @@
+"""
+Unit tests for window() function implementation.
+
+This module contains tests for the window() function implementation with
+different combinations of optional arguments.
+"""
+import unittest
+from typing import Optional
+
+from cloud_dataframe.type_system.column import (
+    WindowFunction, Window, ColumnReference, sum, rank, row, unbounded, window,
+    FunctionExpression, LiteralExpression
+)
+from cloud_dataframe.core.dataframe import OrderByClause, Sort
+
+
+class TestWindowFunction(unittest.TestCase):
+    """Test cases for window() function implementation."""
+    
+    def test_window_with_no_args(self):
+        """Test window() with no arguments."""
+        expr = window()
+        
+        self.assertIsInstance(expr, WindowFunction)
+        self.assertEqual(expr.function_name, "WINDOW")
+        self.assertIsInstance(expr.window, Window)
+        self.assertEqual(len(expr.window.partition_by), 0)
+        self.assertEqual(len(expr.window.order_by), 0)
+        self.assertIsNone(expr.window.frame)
+    
+    def test_window_with_func_arg(self):
+        """Test window() with only func argument."""
+        sum_func = sum(ColumnReference(name="salary"))
+        expr = window(func=sum_func)
+        
+        self.assertIsInstance(expr, WindowFunction)
+        self.assertEqual(expr.function_name, "SUM")
+        self.assertIsInstance(expr.window, Window)
+        self.assertEqual(len(expr.window.partition_by), 0)
+        self.assertEqual(len(expr.window.order_by), 0)
+        self.assertIsNone(expr.window.frame)
+        
+        self.assertEqual(len(expr.parameters), 1)
+        self.assertIsInstance(expr.parameters[0], ColumnReference)
+        self.assertEqual(expr.parameters[0].name, "salary")
+    
+    def test_window_with_partition_arg(self):
+        """Test window() with only partition argument."""
+        dept_col = ColumnReference(name="department")
+        expr = window(partition=dept_col)
+        
+        self.assertIsInstance(expr, WindowFunction)
+        self.assertEqual(expr.function_name, "WINDOW")
+        self.assertIsInstance(expr.window, Window)
+        
+        self.assertEqual(len(expr.window.partition_by), 1)
+        self.assertIsInstance(expr.window.partition_by[0], ColumnReference)
+        self.assertEqual(expr.window.partition_by[0].name, "department")
+        
+        self.assertEqual(len(expr.window.order_by), 0)
+        self.assertIsNone(expr.window.frame)
+    
+    def test_window_with_order_by_arg(self):
+        """Test window() with only order_by argument."""
+        salary_col = ColumnReference(name="salary")
+        expr = window(order_by=salary_col)
+        
+        self.assertIsInstance(expr, WindowFunction)
+        self.assertEqual(expr.function_name, "WINDOW")
+        self.assertIsInstance(expr.window, Window)
+        
+        self.assertEqual(len(expr.window.order_by), 1)
+        self.assertEqual(expr.window.order_by[0].expression.name, "salary")
+        
+        self.assertEqual(len(expr.window.partition_by), 0)
+        self.assertIsNone(expr.window.frame)
+    
+    def test_window_with_frame_arg(self):
+        """Test window() with only frame argument."""
+        frame = row(unbounded(), 0)  # unbounded preceding to current row
+        expr = window(frame=frame)
+        
+        self.assertIsInstance(expr, WindowFunction)
+        self.assertEqual(expr.function_name, "WINDOW")
+        self.assertIsInstance(expr.window, Window)
+        
+        self.assertIsNotNone(expr.window.frame)
+        self.assertEqual(expr.window.frame.type, "ROWS")
+        self.assertTrue(expr.window.frame.is_unbounded_start)
+        self.assertFalse(expr.window.frame.is_unbounded_end)
+        
+        self.assertEqual(len(expr.window.partition_by), 0)
+        self.assertEqual(len(expr.window.order_by), 0)
+    
+    def test_window_with_multiple_args(self):
+        """Test window() with multiple arguments."""
+        dept_col = ColumnReference(name="department")
+        salary_col = ColumnReference(name="salary")
+        rank_func = rank()
+        
+        expr = window(
+            func=rank_func,
+            partition=dept_col,
+            order_by=salary_col
+        )
+        
+        self.assertIsInstance(expr, WindowFunction)
+        self.assertEqual(expr.function_name, "RANK")
+        self.assertIsInstance(expr.window, Window)
+        
+        self.assertEqual(len(expr.window.partition_by), 1)
+        self.assertIsInstance(expr.window.partition_by[0], ColumnReference)
+        self.assertEqual(expr.window.partition_by[0].name, "department")
+        
+        self.assertEqual(len(expr.window.order_by), 1)
+        self.assertEqual(expr.window.order_by[0].expression.name, "salary")
+        
+        self.assertIsNone(expr.window.frame)
+    
+    def test_window_with_all_args(self):
+        """Test window() with all arguments."""
+        dept_col = ColumnReference(name="department")
+        salary_col = ColumnReference(name="salary")
+        rank_func = rank()
+        frame = row(unbounded(), 0)  # unbounded preceding to current row
+        
+        expr = window(
+            func=rank_func,
+            partition=dept_col,
+            order_by=salary_col,
+            frame=frame
+        )
+        
+        self.assertIsInstance(expr, WindowFunction)
+        self.assertEqual(expr.function_name, "RANK")
+        self.assertIsInstance(expr.window, Window)
+        
+        self.assertEqual(len(expr.window.partition_by), 1)
+        self.assertIsInstance(expr.window.partition_by[0], ColumnReference)
+        self.assertEqual(expr.window.partition_by[0].name, "department")
+        
+        self.assertEqual(len(expr.window.order_by), 1)
+        self.assertEqual(expr.window.order_by[0].expression.name, "salary")
+        
+        self.assertIsNotNone(expr.window.frame)
+        self.assertEqual(expr.window.frame.type, "ROWS")
+        self.assertTrue(expr.window.frame.is_unbounded_start)
+        self.assertFalse(expr.window.frame.is_unbounded_end)
+    
+    def test_window_with_array_partition(self):
+        """Test window() with array partition_by."""
+        dept_col = ColumnReference(name="department")
+        id_col = ColumnReference(name="id")
+        rank_func = rank()
+        
+        expr = window(
+            func=rank_func,
+            partition=[dept_col, id_col]
+        )
+        
+        self.assertIsInstance(expr, WindowFunction)
+        self.assertEqual(expr.function_name, "RANK")
+        self.assertIsInstance(expr.window, Window)
+        
+        self.assertEqual(len(expr.window.partition_by), 2)
+        self.assertEqual(expr.window.partition_by[0].name, "department")
+        self.assertEqual(expr.window.partition_by[1].name, "id")
+    
+    def test_window_with_array_order_by(self):
+        """Test window() with array order_by."""
+        salary_col = ColumnReference(name="salary")
+        id_col = ColumnReference(name="id")
+        rank_func = rank()
+        
+        expr = window(
+            func=rank_func,
+            order_by=[salary_col, id_col]
+        )
+        
+        self.assertIsInstance(expr, WindowFunction)
+        self.assertEqual(expr.function_name, "RANK")
+        self.assertIsInstance(expr.window, Window)
+        
+        self.assertEqual(len(expr.window.order_by), 2)
+        self.assertEqual(expr.window.order_by[0].expression.name, "salary")
+        self.assertEqual(expr.window.order_by[1].expression.name, "id")
+    
+    def test_window_with_order_by_direction(self):
+        """Test window() with order_by direction specified."""
+        salary_col = ColumnReference(name="salary")
+        id_col = ColumnReference(name="id")
+        rank_func = rank()
+        
+        salary_desc = OrderByClause(expression=salary_col, direction=Sort.DESC)
+        id_asc = OrderByClause(expression=id_col, direction=Sort.ASC)
+        
+        expr = window(
+            func=rank_func,
+            order_by=[salary_desc, id_asc]
+        )
+        
+        self.assertIsInstance(expr, WindowFunction)
+        self.assertEqual(expr.function_name, "RANK")
+        self.assertIsInstance(expr.window, Window)
+        
+        self.assertEqual(len(expr.window.order_by), 2)
+        self.assertEqual(expr.window.order_by[0].expression.name, "salary")
+        self.assertEqual(expr.window.order_by[0].direction, Sort.DESC)
+        self.assertEqual(expr.window.order_by[1].expression.name, "id")
+        self.assertEqual(expr.window.order_by[1].direction, Sort.ASC)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cloud_dataframe/tests/unit/test_window_parsing.py
+++ b/cloud_dataframe/tests/unit/test_window_parsing.py
@@ -1,0 +1,207 @@
+"""
+Unit tests for parsing window() function expressions.
+
+This module contains tests for parsing window() function expressions with
+different combinations of optional arguments.
+"""
+import unittest
+from typing import Optional
+
+from cloud_dataframe.utils.lambda_parser import LambdaParser, parse_lambda
+from cloud_dataframe.type_system.schema import TableSchema
+from cloud_dataframe.type_system.column import (
+    WindowFunction, Window, ColumnReference, sum, rank, row, unbounded, window
+)
+
+
+class TestWindowParsing(unittest.TestCase):
+    """Test cases for parsing window() function expressions."""
+    
+    def setUp(self):
+        """Set up test fixtures."""
+        self.schema = TableSchema(
+            name="Employee",
+            columns={
+                "id": int,
+                "name": str,
+                "department": str,
+                "salary": float,
+            }
+        )
+    
+    def test_window_with_no_args(self):
+        """Test parsing window() with no arguments."""
+        window_func = window()
+        
+        self.assertIsInstance(window_func, WindowFunction)
+        self.assertEqual(window_func.function_name, "WINDOW")
+        self.assertIsInstance(window_func.window, Window)
+        self.assertEqual(len(window_func.window.partition_by), 0)
+        self.assertEqual(len(window_func.window.order_by), 0)
+        self.assertIsNone(window_func.window.frame)
+    
+    def test_window_with_func_arg(self):
+        """Test parsing window() with only func argument."""
+        salary_col = ColumnReference(name="salary")
+        sum_func = sum(salary_col)
+        
+        window_func = window(func=sum_func)
+        
+        self.assertIsInstance(window_func, WindowFunction)
+        self.assertEqual(window_func.function_name, "SUM")
+        self.assertIsInstance(window_func.window, Window)
+        self.assertEqual(len(window_func.window.partition_by), 0)
+        self.assertEqual(len(window_func.window.order_by), 0)
+        self.assertIsNone(window_func.window.frame)
+        
+        self.assertEqual(len(window_func.parameters), 1)
+        self.assertIsInstance(window_func.parameters[0], ColumnReference)
+        self.assertEqual(window_func.parameters[0].name, "salary")
+    
+    def test_window_with_partition_arg(self):
+        """Test parsing window() with only partition argument."""
+        dept_col = ColumnReference(name="department")
+        
+        window_func = window(partition=dept_col)
+        
+        self.assertIsInstance(window_func, WindowFunction)
+        self.assertEqual(window_func.function_name, "WINDOW")
+        self.assertIsInstance(window_func.window, Window)
+        
+        self.assertEqual(len(window_func.window.partition_by), 1)
+        self.assertIsInstance(window_func.window.partition_by[0], ColumnReference)
+        self.assertEqual(window_func.window.partition_by[0].name, "department")
+        
+        self.assertEqual(len(window_func.window.order_by), 0)
+        self.assertIsNone(window_func.window.frame)
+    
+    def test_window_with_order_by_arg(self):
+        """Test parsing window() with only order_by argument."""
+        salary_col = ColumnReference(name="salary")
+        
+        window_func = window(order_by=salary_col)
+        
+        self.assertIsInstance(window_func, WindowFunction)
+        self.assertEqual(window_func.function_name, "WINDOW")
+        self.assertIsInstance(window_func.window, Window)
+        
+        self.assertEqual(len(window_func.window.order_by), 1)
+        self.assertEqual(window_func.window.order_by[0].expression.name, "salary")
+        
+        self.assertEqual(len(window_func.window.partition_by), 0)
+        self.assertIsNone(window_func.window.frame)
+    
+    def test_window_with_frame_arg(self):
+        """Test parsing window() with only frame argument."""
+        frame = row(unbounded(), 0)  # unbounded preceding to current row
+        
+        window_func = window(frame=frame)
+        
+        self.assertIsInstance(window_func, WindowFunction)
+        self.assertEqual(window_func.function_name, "WINDOW")
+        self.assertIsInstance(window_func.window, Window)
+        
+        self.assertIsNotNone(window_func.window.frame)
+        self.assertEqual(window_func.window.frame.type, "ROWS")
+        self.assertTrue(window_func.window.frame.is_unbounded_start)
+        self.assertFalse(window_func.window.frame.is_unbounded_end)
+        
+        self.assertEqual(len(window_func.window.partition_by), 0)
+        self.assertEqual(len(window_func.window.order_by), 0)
+    
+    def test_window_with_multiple_args(self):
+        """Test parsing window() with multiple arguments."""
+        dept_col = ColumnReference(name="department")
+        salary_col = ColumnReference(name="salary")
+        rank_func = rank()
+        
+        window_func = window(
+            func=rank_func,
+            partition=dept_col,
+            order_by=salary_col
+        )
+        
+        self.assertIsInstance(window_func, WindowFunction)
+        self.assertEqual(window_func.function_name, "RANK")
+        self.assertIsInstance(window_func.window, Window)
+        
+        self.assertEqual(len(window_func.window.partition_by), 1)
+        self.assertIsInstance(window_func.window.partition_by[0], ColumnReference)
+        self.assertEqual(window_func.window.partition_by[0].name, "department")
+        
+        self.assertEqual(len(window_func.window.order_by), 1)
+        self.assertEqual(window_func.window.order_by[0].expression.name, "salary")
+        
+        self.assertIsNone(window_func.window.frame)
+    
+    def test_window_with_all_args(self):
+        """Test parsing window() with all arguments."""
+        dept_col = ColumnReference(name="department")
+        salary_col = ColumnReference(name="salary")
+        rank_func = rank()
+        frame = row(unbounded(), 0)  # unbounded preceding to current row
+        
+        window_func = window(
+            func=rank_func,
+            partition=dept_col,
+            order_by=salary_col,
+            frame=frame
+        )
+        
+        self.assertIsInstance(window_func, WindowFunction)
+        self.assertEqual(window_func.function_name, "RANK")
+        self.assertIsInstance(window_func.window, Window)
+        
+        self.assertEqual(len(window_func.window.partition_by), 1)
+        self.assertIsInstance(window_func.window.partition_by[0], ColumnReference)
+        self.assertEqual(window_func.window.partition_by[0].name, "department")
+        
+        self.assertEqual(len(window_func.window.order_by), 1)
+        self.assertEqual(window_func.window.order_by[0].expression.name, "salary")
+        
+        self.assertIsNotNone(window_func.window.frame)
+        self.assertEqual(window_func.window.frame.type, "ROWS")
+        self.assertTrue(window_func.window.frame.is_unbounded_start)
+        self.assertFalse(window_func.window.frame.is_unbounded_end)
+    
+    def test_window_with_array_partition(self):
+        """Test parsing window() with array partition_by."""
+        dept_col = ColumnReference(name="department")
+        id_col = ColumnReference(name="id")
+        rank_func = rank()
+        
+        window_func = window(
+            func=rank_func,
+            partition=[dept_col, id_col]
+        )
+        
+        self.assertIsInstance(window_func, WindowFunction)
+        self.assertEqual(window_func.function_name, "RANK")
+        self.assertIsInstance(window_func.window, Window)
+        
+        self.assertEqual(len(window_func.window.partition_by), 2)
+        self.assertEqual(window_func.window.partition_by[0].name, "department")
+        self.assertEqual(window_func.window.partition_by[1].name, "id")
+    
+    def test_window_with_array_order_by(self):
+        """Test parsing window() with array order_by."""
+        salary_col = ColumnReference(name="salary")
+        id_col = ColumnReference(name="id")
+        rank_func = rank()
+        
+        window_func = window(
+            func=rank_func,
+            order_by=[salary_col, id_col]
+        )
+        
+        self.assertIsInstance(window_func, WindowFunction)
+        self.assertEqual(window_func.function_name, "RANK")
+        self.assertIsInstance(window_func.window, Window)
+        
+        self.assertEqual(len(window_func.window.order_by), 2)
+        self.assertEqual(window_func.window.order_by[0].expression.name, "salary")
+        self.assertEqual(window_func.window.order_by[1].expression.name, "id")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cloud_dataframe/type_system/__init__.py
+++ b/cloud_dataframe/type_system/__init__.py
@@ -1,0 +1,18 @@
+"""
+Type system for the cloud-dataframe library.
+
+This module exports the core type system classes and functions.
+"""
+from .column import (
+    Expression, LiteralExpression, ColumnReference, FunctionExpression,
+    ScalarFunction, AggregateFunction, WindowFunction,
+    SumFunction, AvgFunction, CountFunction, MinFunction, MaxFunction,
+    RowNumberFunction, RankFunction, DenseRankFunction,
+    Column, Window, Frame,
+    as_column, col, literal,
+    sum, avg, count, min, max,
+    row_number, rank, dense_rank, over, window,  # Added window function here
+    row, range, unbounded,
+    date_diff
+)
+from .schema import TableSchema

--- a/cloud_dataframe/utils/lambda_parser.py
+++ b/cloud_dataframe/utils/lambda_parser.py
@@ -195,6 +195,30 @@ class LambdaParser:
                             raise ValueError(f"Parse Error: {str(nested_err)}")
                     else:
                         raise ValueError(f"Parse Error: {str(syntax_err)}")
+                elif "'(' was never closed" in str(syntax_err):
+                    paren_count = source.count('(') - source.count(')')
+                    if paren_count > 0:
+                        fixed_source = source + ')' * paren_count
+                        try:
+                            tree = ast.parse(fixed_source.strip())
+                            
+                            # Find the lambda expression in the AST
+                            lambda_node = None
+                            for node in ast.walk(tree):
+                                if isinstance(node, ast.Lambda):
+                                    lambda_node = node
+                                    break
+                            
+                            if not lambda_node:
+                                raise ValueError("Could not find lambda expression in source code")
+                            
+                            # Parse the lambda body
+                            result = LambdaParser._parse_expression(lambda_node.body, lambda_node.args.args, table_schema)
+                            return result
+                        except SyntaxError as nested_err:
+                            raise ValueError(f"Parse Error: {str(nested_err)}")
+                    else:
+                        raise ValueError(f"Parse Error: {str(syntax_err)}")
                 else:
                     raise ValueError(f"Parse Error: {str(syntax_err)}")
         except Exception as e:


### PR DESCRIPTION
# Add window() function parsing to lambda_parser with optional arguments

This PR adds support for parsing window() function calls in lambda expressions with optional arguments:
- func: Optional window function to apply
- partition: Optional list of expressions to partition by
- order_by: Optional list of expressions to order by
- frame: Optional frame specification

## Implementation Details
- Added window() function to column.py with support for all optional arguments
- Updated lambda_parser.py to handle window() function calls
- Added unit tests for window() function implementation
- Added integration tests with SQL comparison to verify window function works with DuckDB

## Testing
- Added unit tests for window() function implementation
- Added integration tests with SQL comparison to verify window function works with DuckDB

Link to Devin run: https://app.devin.ai/sessions/03b0f8718b954794a40fb6c193547178
Requested by: Neema Raphael