### PR TITLE
Modify order_by() function to support structured lambda syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ __pycache__/
 
 # Debug files
 debug_window_test.py
+__pycache__/
+*.pyc
+__pycache__/
+*.pyc

--- a/cloud_dataframe/tests/integration/test_order_by_duckdb.py
+++ b/cloud_dataframe/tests/integration/test_order_by_duckdb.py
@@ -1,0 +1,152 @@
+"""
+Integration tests for order_by() function with DuckDB.
+
+This module contains comprehensive tests for the order_by() function
+with all supported lambda formats, verifying execution with DuckDB.
+"""
+import unittest
+import duckdb
+from typing import Optional
+
+from cloud_dataframe.core.dataframe import DataFrame, Sort
+from cloud_dataframe.type_system.schema import TableSchema
+
+
+class TestOrderByDuckDB(unittest.TestCase):
+    """Integration tests for order_by() function with DuckDB."""
+    
+    def setUp(self):
+        """Set up test fixtures."""
+        self.schema = TableSchema(
+            name="Employee",
+            columns={
+                "id": int,
+                "name": str,
+                "department": str,
+                "location": str,
+                "salary": float,
+                "hire_date": str
+            }
+        )
+        
+        self.df = DataFrame.from_table_schema("employees", self.schema)
+        
+        self.conn = duckdb.connect(":memory:")
+        
+        self.conn.execute("""
+            CREATE TABLE employees (
+                id INTEGER,
+                name VARCHAR,
+                department VARCHAR,
+                location VARCHAR,
+                salary FLOAT,
+                hire_date VARCHAR
+            )
+        """)
+        
+        self.conn.execute("""
+            INSERT INTO employees VALUES
+            (1, 'Alice', 'Engineering', 'New York', 120000, '2020-01-15'),
+            (2, 'Bob', 'Engineering', 'San Francisco', 110000, '2020-03-20'),
+            (3, 'Charlie', 'Sales', 'Chicago', 95000, '2021-02-10'),
+            (4, 'David', 'Sales', 'Chicago', 85000, '2020-05-15'),
+            (5, 'Eve', 'Marketing', 'New York', 90000, '2021-06-01'),
+            (6, 'Frank', 'Marketing', 'San Francisco', 105000, '2020-01-10')
+        """)
+    
+    def tearDown(self):
+        """Clean up test fixtures."""
+        self.conn.close()
+    
+    def test_single_expression_format(self):
+        """Test single expression format (lambda x: x.col1)."""
+        ordered_df = self.df.order_by(lambda x: x.salary)
+        
+        result = self.conn.execute(ordered_df.to_sql()).fetchall()
+        
+        self.assertEqual(len(result), 6)
+        
+        for i in range(1, len(result)):
+            self.assertLessEqual(result[i-1][4], result[i][4])
+    
+    def test_single_tuple_format(self):
+        """Test single tuple format (lambda x: (x.col1, Sort.DESC))."""
+        ordered_df = self.df.order_by(lambda x: (x.salary, Sort.DESC))
+        
+        result = self.conn.execute(ordered_df.to_sql()).fetchall()
+        
+        self.assertEqual(len(result), 6)
+        
+        for i in range(1, len(result)):
+            self.assertGreaterEqual(result[i-1][4], result[i][4])
+    
+    def test_array_format_with_mix(self):
+        """Test array format with mix of expressions and tuples."""
+        ordered_df = self.df.order_by(lambda x: [
+            x.department,  # Department ascending (default)
+            (x.salary, Sort.DESC)  # Salary descending
+        ])
+        
+        result = self.conn.execute(ordered_df.to_sql()).fetchall()
+        
+        self.assertEqual(len(result), 6)
+        
+        dept_groups = {}
+        for row in result:
+            dept = row[2]
+            if dept not in dept_groups:
+                dept_groups[dept] = []
+            dept_groups[dept].append(row)
+        
+        depts = list(dept_groups.keys())
+        self.assertEqual(depts, sorted(depts))
+        
+        for dept, rows in dept_groups.items():
+            for i in range(1, len(rows)):
+                self.assertGreaterEqual(rows[i-1][4], rows[i][4])
+    
+    def test_array_format_with_all_tuples(self):
+        """Test array format with all tuples."""
+        ordered_df = self.df.order_by(lambda x: [
+            (x.department, Sort.DESC),
+            (x.location, Sort.ASC),
+            (x.salary, Sort.DESC)
+        ])
+        
+        result = self.conn.execute(ordered_df.to_sql()).fetchall()
+        
+        self.assertEqual(len(result), 6)
+        
+        depts = [row[2] for row in result]
+        sorted_depts = sorted(set(depts), reverse=True)
+        
+        dept_change_indices = [i for i in range(1, len(result)) if result[i][2] != result[i-1][2]]
+        dept_change_indices = [0] + dept_change_indices
+        
+        observed_depts = [result[i][2] for i in dept_change_indices]
+        self.assertEqual(observed_depts, sorted_depts)
+        
+        for i in range(len(dept_change_indices)):
+            start = dept_change_indices[i]
+            end = dept_change_indices[i+1] if i+1 < len(dept_change_indices) else len(result)
+            
+            dept_rows = result[start:end]
+            locations = [row[3] for row in dept_rows]
+            
+            loc_groups = {}
+            for row in dept_rows:
+                loc = row[3]
+                if loc not in loc_groups:
+                    loc_groups[loc] = []
+                loc_groups[loc].append(row)
+            
+            loc_keys = list(loc_groups.keys())
+            self.assertEqual(loc_keys, sorted(loc_keys))
+            
+            for loc, loc_rows in loc_groups.items():
+                for j in range(1, len(loc_rows)):
+                    self.assertGreaterEqual(loc_rows[j-1][4], loc_rows[j][4])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cloud_dataframe/tests/integration/test_per_column_sort_duckdb.py
+++ b/cloud_dataframe/tests/integration/test_per_column_sort_duckdb.py
@@ -107,9 +107,10 @@ class TestPerColumnSortDuckDB(unittest.TestCase):
         """Test mix of tuple and non-tuple specifications with DuckDB."""
         # Test mix of tuple and non-tuple specifications
         ordered_df = self.df.order_by(
-            lambda x: [(x.location, Sort.ASC)],  # Location in ascending order
-            lambda x: x.salary,               # Salary in default order (ASC)
-            desc=False                        # Default direction is ASC for non-tuple columns
+            lambda x: [
+                (x.location, Sort.ASC),  # Location in ascending order
+                x.salary                 # Salary in default order (ASC)
+            ]
         )
         
         # Execute the query

--- a/cloud_dataframe/tests/integration/test_sql_generation.py
+++ b/cloud_dataframe/tests/integration/test_sql_generation.py
@@ -85,7 +85,8 @@ class TestDuckDBSQLGeneration(unittest.TestCase):
     
     def test_order_by(self):
         """Test generating SQL for an ORDER BY query."""
-        df = DataFrame.from_("employees", alias="x").order_by(lambda x: x.salary, desc=True)
+        from cloud_dataframe.core.dataframe import Sort
+        df = DataFrame.from_("employees", alias="x").order_by(lambda x: (x.salary, Sort.DESC))
         
         sql = df.to_sql(dialect="duckdb")
         expected_sql = "SELECT *\nFROM employees x\nORDER BY x.salary DESC"

--- a/cloud_dataframe/tests/integration/test_typed_properties.py
+++ b/cloud_dataframe/tests/integration/test_typed_properties.py
@@ -125,7 +125,8 @@ class TestTypedProperties(unittest.TestCase):
         df = DataFrame.from_table_schema("employees", schema)
         
         # Order by using typed properties
-        ordered_df = df.order_by(lambda x: x.salary, desc=True)
+        from cloud_dataframe.core.dataframe import Sort
+        ordered_df = df.order_by(lambda x: (x.salary, Sort.DESC))
         
         sql = ordered_df.to_sql(dialect="duckdb")
         expected_sql = "SELECT *\nFROM employees x\nORDER BY x.salary DESC"

--- a/cloud_dataframe/tests/integration/test_window_examples_duckdb.py
+++ b/cloud_dataframe/tests/integration/test_window_examples_duckdb.py
@@ -66,8 +66,7 @@ class TestWindowExamplesDuckDB(unittest.TestCase):
             lambda x: x.sales,
             lambda x: (running_total := window(func=sum(x.sales), partition=x.product_id, order_by=x.date, frame=row(unbounded(), 0)))
         ).order_by(
-            lambda x: x.product_id,
-            lambda x: x.date
+            lambda x: [x.product_id, x.date]
         )
         
         # Generate SQL
@@ -102,8 +101,7 @@ class TestWindowExamplesDuckDB(unittest.TestCase):
             lambda x: x.sales,
             lambda x: (moving_avg := window(func=avg(x.sales), partition=x.product_id, order_by=x.date, frame=row(1, 1)))
         ).order_by(
-            lambda x: x.product_id,
-            lambda x: x.date
+            lambda x: [x.product_id, x.date]
         )
         
         # Generate SQL
@@ -132,8 +130,7 @@ class TestWindowExamplesDuckDB(unittest.TestCase):
             lambda x: x.sales,
             lambda x: (adjusted_total := window(func=sum(x.sales + 10), partition=x.region, frame=range(unbounded(), 0)))
         ).order_by(
-            lambda x: x.region,
-            lambda x: x.product_id
+            lambda x: [x.region, x.product_id]
         )
         
         # Generate SQL

--- a/cloud_dataframe/tests/integration/test_window_frames_duckdb.py
+++ b/cloud_dataframe/tests/integration/test_window_frames_duckdb.py
@@ -69,8 +69,7 @@ class TestWindowFramesDuckDB(unittest.TestCase):
                 frame=row(unbounded(), 0)  # unbounded preceding to current row
             ))
         ).order_by(
-            lambda x: x.department,
-            lambda x: x.salary
+            lambda x: [x.department, x.salary]
         )
         
         # Generate SQL
@@ -156,8 +155,7 @@ class TestWindowFramesDuckDB(unittest.TestCase):
                 frame=row(unbounded(), 0)
             ))
         ).order_by(
-            lambda x: x.department,
-            lambda x: x.id
+            lambda x: [x.department, x.id]
         )
         
         # Generate SQL

--- a/cloud_dataframe/tests/unit/test_array_lambda.py
+++ b/cloud_dataframe/tests/unit/test_array_lambda.py
@@ -101,19 +101,15 @@ class TestArrayLambda(unittest.TestCase):
         expected_sql = "SELECT x.department, x.location, x.is_manager, AVG(x.salary) AS avg_salary\nFROM employees x\nGROUP BY x.department, x.location, x.is_manager"
         self.assertEqual(sql.strip(), expected_sql.strip())
         
-        # Test mixing array and single lambdas in order_by
+        from cloud_dataframe.core.dataframe import Sort
         ordered_df = self.df.order_by(
-            lambda x: [x.department, x.location],
-            lambda x: x.salary,
-            desc=True
+            lambda x: [x.department, x.location, (x.salary, Sort.DESC)]
         )
         
         # Check the SQL generation
         sql = ordered_df.to_sql(dialect="duckdb")
-        # Get the actual SQL to see what's being generated
-        print(f"Generated SQL: {sql}")
-        # The test will pass with the actual SQL output
-        self.assertTrue("ORDER BY" in sql)
+        expected_sql = "SELECT x.name, x.department, x.salary\nFROM employees x\nORDER BY x.department ASC, x.location ASC, x.salary DESC"
+        self.assertEqual(sql.strip(), expected_sql.strip())
 
 
 if __name__ == "__main__":

--- a/cloud_dataframe/tests/unit/test_dataframe.py
+++ b/cloud_dataframe/tests/unit/test_dataframe.py
@@ -60,8 +60,9 @@ class TestDataFrame(unittest.TestCase):
     
     def test_order_by(self):
         """Test the order_by method."""
+        from cloud_dataframe.core.dataframe import Sort
         df = DataFrame.from_("employees")
-        ordered_df = df.order_by(lambda x: x.salary, desc=True)
+        ordered_df = df.order_by(lambda x: (x.salary, Sort.DESC))
         
         self.assertEqual(len(ordered_df.order_by_clauses), 1)
     

--- a/cloud_dataframe/tests/unit/test_dynamic_dataclass.py
+++ b/cloud_dataframe/tests/unit/test_dynamic_dataclass.py
@@ -117,7 +117,8 @@ class TestDataframeWithTypedProperties(unittest.TestCase):
     def test_order_by_with_typed_properties(self):
         """Test ordering with typed properties."""
         # Test order_by with lambda using typed properties
-        ordered_df = self.df.order_by(lambda x: x.salary, desc=True)
+        from cloud_dataframe.core.dataframe import Sort
+        ordered_df = self.df.order_by(lambda x: (x.salary, Sort.DESC))
         
         # Check the SQL generation
         sql = ordered_df.to_sql(dialect="duckdb")
@@ -126,14 +127,15 @@ class TestDataframeWithTypedProperties(unittest.TestCase):
         
         # Test order_by with multiple columns
         ordered_df = self.df.order_by(
-            lambda x: x.department,
-            lambda x: x.salary, 
-            desc=True
+            lambda x: [
+                x.department,
+                (x.salary, Sort.DESC)
+            ]
         )
         
         # Check the SQL generation
         sql = ordered_df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT *\nFROM employees x\nORDER BY x.salary DESC, x.department DESC, x.salary DESC"
+        expected_sql = "SELECT *\nFROM employees x\nORDER BY x.salary DESC, x.department ASC, x.salary DESC"
         self.assertEqual(sql.strip(), expected_sql.strip())
     
     def test_get_table_class(self):

--- a/cloud_dataframe/tests/unit/test_order_by_restrictions.py
+++ b/cloud_dataframe/tests/unit/test_order_by_restrictions.py
@@ -1,0 +1,60 @@
+"""
+Unit tests for order_by() function restrictions.
+
+This module contains tests to verify that unsupported formats
+for the order_by() function raise appropriate errors.
+"""
+import unittest
+from typing import Optional
+
+from cloud_dataframe.core.dataframe import DataFrame, Sort, OrderByClause
+from cloud_dataframe.type_system.schema import TableSchema
+from cloud_dataframe.type_system.column import col
+
+
+class TestOrderByRestrictions(unittest.TestCase):
+    """Test cases for order_by() function restrictions."""
+    
+    def setUp(self):
+        """Set up test fixtures."""
+        self.schema = TableSchema(
+            name="Employee",
+            columns={
+                "id": int,
+                "name": str,
+                "department": str,
+                "salary": float
+            }
+        )
+        
+        self.df = DataFrame.from_table_schema("employees", self.schema)
+    
+    def test_multiple_lambda_functions_not_supported(self):
+        """Test that multiple lambda functions are not supported."""
+        with self.assertRaises(TypeError):
+            self.df.order_by(
+                lambda x: x.department,
+                lambda x: x.salary
+            )
+    
+    def test_orderby_clause_not_supported(self):
+        """Test that OrderByClause objects are not supported."""
+        with self.assertRaises(ValueError):
+            self.df.order_by(OrderByClause(
+                expression=col("department"),
+                direction=Sort.ASC
+            ))
+    
+    def test_expression_objects_not_supported(self):
+        """Test that Expression objects are not supported."""
+        with self.assertRaises(ValueError):
+            self.df.order_by(col("department"))
+    
+    def test_desc_parameter_not_supported(self):
+        """Test that the desc parameter is not supported."""
+        with self.assertRaises(TypeError):
+            self.df.order_by(lambda x: x.department, desc=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/cloud_dataframe/tests/unit/test_per_column_sort.py
+++ b/cloud_dataframe/tests/unit/test_per_column_sort.py
@@ -55,14 +55,15 @@ class TestPerColumnSort(unittest.TestCase):
         """Test mix of tuple and non-tuple specifications."""
         # Test mix of tuple and non-tuple specifications
         ordered_df = self.df.order_by(
-            lambda x: [(x.department, Sort.DESC)],  # Department in descending order
-            lambda x: x.salary,                  # Salary in default order
-            desc=True                            # Default direction is DESC for non-tuple columns
+            lambda x: [
+                (x.department, Sort.DESC),  # Department in descending order
+                x.salary                    # Salary in default ascending order
+            ]
         )
         
         # Check the SQL generation
         sql = ordered_df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT *\nFROM employees x\nORDER BY x.department DESC, x.salary DESC"
+        expected_sql = "SELECT *\nFROM employees x\nORDER BY x.department DESC, x.salary ASC"
         self.assertEqual(sql.strip(), expected_sql.strip())
     
     def test_enum_sort_direction(self):


### PR DESCRIPTION
# Modify order_by() function to support structured lambda syntax

This PR modifies the order_by() function to support a more structured lambda syntax for sorting operations.

## Supported formats:
1. Single expression: `order_by(lambda x: x.col1)`
2. Single tuple with Sort enum: `order_by(lambda x: (x.col1, Sort.DESC))`
3. Array of expressions and tuples: `order_by(lambda x: [x.col1, (x.col2, Sort.DESC), x.col3])`

## Breaking changes:
- Removed support for multiple lambda functions
- Removed support for OrderByClause objects
- Removed support for Expression objects
- Removed support for the global desc parameter

## Testing:
- Added comprehensive integration tests using DuckDB to verify sorting behavior
- Added unit tests to verify restrictions on unsupported formats
- Updated existing tests to use the new lambda syntax formats
- All tests are passing (175 tests)

Link to Devin run: https://app.devin.ai/sessions/b408ea7701134c96a0e58409bbd25fa5
Requested by: neema.raphael@gs.com