### PR TITLE
Remove duplicate DateDiff implementations

### DIFF
--- a/cloud_dataframe/backends/duckdb/sql_generator.py
+++ b/cloud_dataframe/backends/duckdb/sql_generator.py
@@ -491,11 +491,7 @@ def _generate_function(func: FunctionExpression) -> str:
         
     Returns:
         The generated SQL string for the function
-    """
-    # Map function names to their SQL equivalents if needed
-    func_name_mapping = {
-    }
-    
+    """   
     params_sql = ", ".join(_generate_expression(param) for param in func.parameters)
     
     sql_func_name = func_name_mapping.get(func.function_name, func.function_name)

--- a/cloud_dataframe/backends/duckdb/sql_generator.py
+++ b/cloud_dataframe/backends/duckdb/sql_generator.py
@@ -494,34 +494,9 @@ def _generate_function(func: FunctionExpression) -> str:
     """
     # Map function names to their SQL equivalents if needed
     func_name_mapping = {
-        "DATE_DIFF": "DATEDIFF"
-        # Add more mappings as needed
     }
     
-    # Special handling for date_diff function
-    if func.function_name == "DATE_DIFF":
-        if hasattr(func, 'column_names') and len(func.column_names) == 2:
-            # Use stored column names if available
-            params_sql = ", ".join(func.column_names)
-        elif not func.parameters or "*" in str(func.parameters):
-            if func.parameters and hasattr(func.parameters[0], 'table_alias') and func.parameters[0].table_alias:
-                table_alias = func.parameters[0].table_alias
-                params_sql = f"{table_alias}.start_date, {table_alias}.end_date"
-            else:
-                params_sql = "start_date, end_date"
-        else:
-            # Normal case: generate SQL for each parameter
-            params_sql = ", ".join(_generate_expression(param) for param in func.parameters)
-        
-        # Add 'day' as the first parameter and cast date columns for DuckDB
-        date_parts = params_sql.split(',')
-        start_date = date_parts[0].strip()
-        end_date = date_parts[1].strip()
-        
-        params_sql = f"'day', CAST({start_date} AS DATE), CAST({end_date} AS DATE)"
-    else:
-        # Normal case for other functions
-        params_sql = ", ".join(_generate_expression(param) for param in func.parameters)
+    params_sql = ", ".join(_generate_expression(param) for param in func.parameters)
     
     sql_func_name = func_name_mapping.get(func.function_name, func.function_name)
     return f"{sql_func_name}({params_sql})"

--- a/cloud_dataframe/tests/integration/test_nested_functions_duckdb.py
+++ b/cloud_dataframe/tests/integration/test_nested_functions_duckdb.py
@@ -170,7 +170,7 @@ class TestNestedFunctionsDuckDB(unittest.TestCase):
         df = self.df.select(
             lambda x: x.name,
             lambda x: x.department,
-            lambda x: (days_employed := FunctionRegistry.get_function("date_diff")("day", x.start_date, x.end_date))
+            lambda x: (days_employed := x.date_diff('day', x.start_date, x.end_date))
         )
         
         # Generate SQL and execute it

--- a/cloud_dataframe/tests/integration/test_nested_functions_duckdb.py
+++ b/cloud_dataframe/tests/integration/test_nested_functions_duckdb.py
@@ -11,7 +11,8 @@ from typing import Optional
 
 from cloud_dataframe.core.dataframe import DataFrame
 from cloud_dataframe.type_system.schema import TableSchema
-from cloud_dataframe.type_system.column import sum, avg, count, min, max, date_diff
+from cloud_dataframe.type_system.column import sum, avg, count, min, max
+from cloud_dataframe.functions.registry import FunctionRegistry
 
 
 class TestNestedFunctionsDuckDB(unittest.TestCase):
@@ -169,7 +170,7 @@ class TestNestedFunctionsDuckDB(unittest.TestCase):
         df = self.df.select(
             lambda x: x.name,
             lambda x: x.department,
-            lambda x: (days_employed := date_diff(x.start_date, x.end_date))
+            lambda x: (days_employed := FunctionRegistry.get_function("date_diff")("day", x.start_date, x.end_date))
         )
         
         # Generate SQL and execute it

--- a/cloud_dataframe/tests/unit/test_nested_functions.py
+++ b/cloud_dataframe/tests/unit/test_nested_functions.py
@@ -104,7 +104,7 @@ class TestNestedFunctions(unittest.TestCase):
         df = self.df.select(
             lambda x: x.name,
             lambda x: x.department,
-            lambda x: (days_employed := FunctionRegistry.get_function("date_diff")("day", start_date_col, end_date_col))
+            lambda x: (days_employed := x.date_diff('day', start_date_col, end_date_col))
         )
         
         # Check the SQL generation
@@ -116,7 +116,7 @@ class TestNestedFunctions(unittest.TestCase):
         """Test scalar function in filter."""
         # Test date_diff in filter
         df = self.df.filter(
-            lambda x: FunctionRegistry.get_function("date_diff")("day", x.start_date, x.end_date) > 365
+            lambda x: x.date_diff('day', x.start_date, x.end_date) > 365
         )
         
         # Check the SQL generation

--- a/cloud_dataframe/tests/unit/test_nested_functions.py
+++ b/cloud_dataframe/tests/unit/test_nested_functions.py
@@ -9,7 +9,8 @@ from typing import Optional
 
 from cloud_dataframe.core.dataframe import DataFrame
 from cloud_dataframe.type_system.schema import TableSchema
-from cloud_dataframe.type_system.column import sum, avg, count, min, max, date_diff, ColumnReference
+from cloud_dataframe.type_system.column import sum, avg, count, min, max, ColumnReference
+from cloud_dataframe.functions.registry import FunctionRegistry
 
 
 class TestNestedFunctions(unittest.TestCase):
@@ -103,7 +104,7 @@ class TestNestedFunctions(unittest.TestCase):
         df = self.df.select(
             lambda x: x.name,
             lambda x: x.department,
-            lambda x: (days_employed := date_diff(start_date_col, end_date_col))
+            lambda x: (days_employed := FunctionRegistry.get_function("date_diff")("day", start_date_col, end_date_col))
         )
         
         # Check the SQL generation
@@ -115,7 +116,7 @@ class TestNestedFunctions(unittest.TestCase):
         """Test scalar function in filter."""
         # Test date_diff in filter
         df = self.df.filter(
-            lambda x: date_diff(x.start_date, x.end_date) > 365
+            lambda x: FunctionRegistry.get_function("date_diff")("day", x.start_date, x.end_date) > 365
         )
         
         # Check the SQL generation

--- a/cloud_dataframe/type_system/column.py
+++ b/cloud_dataframe/type_system/column.py
@@ -44,11 +44,6 @@ class ScalarFunction(FunctionExpression):
     pass
 
 
-@dataclass
-class DateDiffFunction(ScalarFunction):
-    """DATE_DIFF scalar function."""
-    pass
-
 
 @dataclass
 class AggregateFunction(FunctionExpression):
@@ -439,82 +434,7 @@ def range(start: Union[int, str] = 0, end: Union[int, str] = 0) -> Frame:
 
 # Scalar functions
 
-def date_diff(expr1: Union[Callable, Expression], expr2: Union[Callable, Expression]) -> DateDiffFunction:
-    """
-    Create a DATE_DIFF scalar function.
-    
-    Args:
-        expr1: First date expression (lambda function or Expression)
-              Example: lambda x: x.start_date
-        expr2: Second date expression (lambda function or Expression)
-              Example: lambda x: x.end_date
-        
-    Returns:
-        A DateDiffFunction expression
-    """
-    from ..utils.lambda_parser import parse_lambda
-    
-    if callable(expr1) and not isinstance(expr1, Expression):
-        parsed_expr1 = parse_lambda(expr1)
-    else:
-        parsed_expr1 = expr1
-    
-    if callable(expr2) and not isinstance(expr2, Expression):
-        parsed_expr2 = parse_lambda(expr2)
-    else:
-        parsed_expr2 = expr2
-    
-    # Store column names for SQL generation
-    col_names = []
-    if isinstance(parsed_expr1, ColumnReference):
-        col_names.append(parsed_expr1.name)
-    if isinstance(parsed_expr2, ColumnReference):
-        col_names.append(parsed_expr2.name)
-    
-    func = DateDiffFunction(
-        function_name="DATE_DIFF",
-        parameters=[parsed_expr1, parsed_expr2]
-    )
-    
-    # Store column names as an attribute for SQL generation
-    if col_names:
-        func.column_names = col_names
-    
-    return func
 
-@dataclass
-class DateDiffFunction(ScalarFunction):
-    """DATE_DIFF scalar function."""
-    pass
-
-
-def date_diff(expr1: Union[Callable, Expression], expr2: Union[Callable, Expression]) -> DateDiffFunction:
-    """
-    Create a DATE_DIFF scalar function.
-    
-    Args:
-        expr1: First date expression
-        expr2: Second date expression
-        
-    Returns:
-        A DateDiffFunction expression
-    """
-    from ..utils.lambda_parser import parse_lambda
-    
-    if callable(expr1):
-        parsed_expr1 = parse_lambda(expr1)
-    else:
-        parsed_expr1 = expr1
-    
-    if callable(expr2):
-        parsed_expr2 = parse_lambda(expr2)
-    else:
-        parsed_expr2 = expr2
-    
-    return DateDiffFunction(
-        function_name="DATE_DIFF",
-        parameters=[parsed_expr1, parsed_expr2]
-    )
 
 
 def window(func: Optional[FunctionExpression] = None,

--- a/cloud_dataframe/utils/lambda_parser.py
+++ b/cloud_dataframe/utils/lambda_parser.py
@@ -12,7 +12,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union, cast
 from ..type_system.column import (
     Expression, LiteralExpression, ColumnReference, 
     SumFunction, AvgFunction, CountFunction, MinFunction, MaxFunction,
-    DateDiffFunction, FunctionExpression, WindowFunction, Window, Frame,
+    FunctionExpression, WindowFunction, Window, Frame,
     RankFunction, RowNumberFunction, DenseRankFunction,
     window, rank, row_number, dense_rank, row, range, unbounded
 )
@@ -105,8 +105,7 @@ class LambdaParser:
         """
         from ..type_system.column import (
             ColumnReference, LiteralExpression, FunctionExpression,
-            SumFunction, AvgFunction, CountFunction, MinFunction, MaxFunction,
-            DateDiffFunction
+            SumFunction, AvgFunction, CountFunction, MinFunction, MaxFunction
         )
         
         if node is None:
@@ -459,12 +458,12 @@ class LambdaParser:
                     except ValueError as e:
                         return FunctionExpression(function_name=node.func.id, parameters=args_list)
                 elif node.func.id in ('date_diff'):
-                    from ..type_system.column import DateDiffFunction
+                    from ..functions.date_functions import DateDiffFunction
                     
                     if len(args_list) != 2:
                         raise ValueError(f"Function {node.func.id}() expects exactly two arguments")
                         
-                    return DateDiffFunction(function_name="DATE_DIFF", parameters=args_list)
+                    return DateDiffFunction(parameters=args_list)
             elif isinstance(node.func, ast.Attribute) and node.func.attr == "alias" and len(node.args) == 1:
                 if isinstance(node.args[0], ast.Constant):
                     alias_name = node.args[0].value

--- a/cloud_dataframe/utils/lambda_parser.py
+++ b/cloud_dataframe/utils/lambda_parser.py
@@ -457,13 +457,6 @@ class LambdaParser:
                         return FunctionRegistry.create_function(node.func.id, args_list)
                     except ValueError as e:
                         return FunctionExpression(function_name=node.func.id, parameters=args_list)
-                elif node.func.id in ('date_diff'):
-                    from ..functions.date_functions import DateDiffFunction
-                    
-                    if len(args_list) != 2:
-                        raise ValueError(f"Function {node.func.id}() expects exactly two arguments")
-                        
-                    return DateDiffFunction(parameters=args_list)
             elif isinstance(node.func, ast.Attribute) and node.func.attr == "alias" and len(node.args) == 1:
                 if isinstance(node.args[0], ast.Constant):
                     alias_name = node.args[0].value


### PR DESCRIPTION
Removed duplicate DateDiff implementations from column.py, lambda_parser.py, and sql_generator.py as requested. Test failures are expected at this stage.

Link to Devin run: https://app.devin.ai/sessions/fcd6a4feeb6f4f4f96a4ef0492d36128
Requested by: Neema Raphael