### PR TITLE
Replace ScalarFunction from column.py with base.py implementation - Comprehensive Changes

### DIFF
--- a/cloud_dataframe/type_system/column.py
+++ b/cloud_dataframe/type_system/column.py
@@ -38,12 +38,6 @@ class FunctionExpression(Expression):
     parameters: List[Expression] = field(default_factory=list)
 
 
-@dataclass
-class ScalarFunction(FunctionExpression):
-    """Base class for scalar functions."""
-    pass
-
-
 
 @dataclass
 class AggregateFunction(FunctionExpression):


### PR DESCRIPTION
# Replace ScalarFunction from column.py with base.py implementation

This PR includes all changes to column.py, __init__.py, and sql_generator.py to replace the duplicate ScalarFunction class with the implementation from base.py.

## Changes
- Removed ScalarFunction class definition from cloud_dataframe/type_system/column.py
- Updated cloud_dataframe/type_system/__init__.py to import ScalarFunction from functions/base.py
- Updated cloud_dataframe/backends/duckdb/sql_generator.py to import ScalarFunction from functions/base.py

## Testing
- All tests pass with the updated implementation

Link to Devin run: https://app.devin.ai/sessions/fcd6a4feeb6f4f4f96a4ef0492d36128
Requested by: Neema.Raphael@gs.com