### PR TITLE
Breaking Change: Add AS keyword to table aliases in SQL generator

### DIFF
--- a/cloud_dataframe/backends/duckdb/sql_generator.py
+++ b/cloud_dataframe/backends/duckdb/sql_generator.py
@@ -531,13 +531,13 @@ def _generate_source(source: Any) -> str:
             table_sql = f"{source.schema}.{table_sql}"
         
         if source.alias:
-            return f"{table_sql} {source.alias}"
+            return f"{table_sql} AS {source.alias}"
         else:
             return table_sql
     
     elif isinstance(source, SubquerySource):
         subquery_sql = generate_sql(source.dataframe)
-        return f"({subquery_sql}) {source.alias}"
+        return f"({subquery_sql}) AS {source.alias}"
     
     elif isinstance(source, JoinOperation):
         left_sql = _generate_source(source.left)
@@ -547,11 +547,11 @@ def _generate_source(source: Any) -> str:
         right_table_alias = source.right_alias if hasattr(source, 'right_alias') and source.right_alias else None
         
         if isinstance(source.left, TableReference) and not source.left.alias and left_table_alias:
-            left_sql = f"{left_sql} {left_table_alias}"
+            left_sql = f"{left_sql} AS {left_table_alias}"
             source.left.alias = left_table_alias
         
         if isinstance(source.right, TableReference) and not source.right.alias and right_table_alias:
-            right_sql = f"{right_sql} {right_table_alias}"
+            right_sql = f"{right_sql} AS {right_table_alias}"
             source.right.alias = right_table_alias
         
         join_type_sql = source.join_type.value

--- a/cloud_dataframe/tests/integration/test_complex_filters.py
+++ b/cloud_dataframe/tests/integration/test_complex_filters.py
@@ -36,7 +36,7 @@ class TestComplexFilterConditions(unittest.TestCase):
         )
         
         sql = df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT *\nFROM employees e\nWHERE e.salary > 50000"
+        expected_sql = "SELECT *\nFROM employees AS e\nWHERE e.salary > 50000"
         self.assertEqual(sql.strip(), expected_sql)
     
     def test_boolean_and_condition(self):
@@ -46,7 +46,7 @@ class TestComplexFilterConditions(unittest.TestCase):
         )
         
         sql = df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT *\nFROM employees e\nWHERE e.salary > 50000 AND e.department = 'Engineering'"
+        expected_sql = "SELECT *\nFROM employees AS e\nWHERE e.salary > 50000 AND e.department = 'Engineering'"
         self.assertEqual(sql.strip(), expected_sql)
     
     def test_boolean_or_condition(self):
@@ -56,7 +56,7 @@ class TestComplexFilterConditions(unittest.TestCase):
         )
         
         sql = df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT *\nFROM employees e\nWHERE (e.department = 'Engineering' OR e.department = 'Sales')"
+        expected_sql = "SELECT *\nFROM employees AS e\nWHERE (e.department = 'Engineering' OR e.department = 'Sales')"
         self.assertEqual(sql.strip(), expected_sql)
     
     def test_complex_boolean_condition(self):
@@ -66,7 +66,7 @@ class TestComplexFilterConditions(unittest.TestCase):
         )
         
         sql = df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT *\nFROM employees e\nWHERE (e.department = 'Engineering' OR e.department = 'Sales') AND e.salary > 60000"
+        expected_sql = "SELECT *\nFROM employees AS e\nWHERE (e.department = 'Engineering' OR e.department = 'Sales') AND e.salary > 60000"
         self.assertEqual(sql.strip(), expected_sql)
     
     def test_multiple_and_conditions(self):
@@ -76,7 +76,7 @@ class TestComplexFilterConditions(unittest.TestCase):
         )
         
         sql = df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT *\nFROM employees e\nWHERE e.salary > 50000 AND e.age > 30 AND e.is_manager = TRUE"
+        expected_sql = "SELECT *\nFROM employees AS e\nWHERE e.salary > 50000 AND e.age > 30 AND e.is_manager = TRUE"
         self.assertEqual(sql.strip(), expected_sql)
     
     def test_multiple_or_conditions(self):
@@ -86,7 +86,7 @@ class TestComplexFilterConditions(unittest.TestCase):
         )
         
         sql = df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT *\nFROM employees e\nWHERE e.department = 'Engineering' OR e.department = 'Sales' OR e.department = 'Marketing'"
+        expected_sql = "SELECT *\nFROM employees AS e\nWHERE e.department = 'Engineering' OR e.department = 'Sales' OR e.department = 'Marketing'"
         self.assertEqual(sql.strip(), expected_sql)
     
     def test_not_equal_condition(self):
@@ -96,7 +96,7 @@ class TestComplexFilterConditions(unittest.TestCase):
         )
         
         sql = df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT *\nFROM employees e\nWHERE e.department != 'HR'"
+        expected_sql = "SELECT *\nFROM employees AS e\nWHERE e.department != 'HR'"
         self.assertEqual(sql.strip(), expected_sql)
     
     def test_less_than_equal_condition(self):
@@ -106,7 +106,7 @@ class TestComplexFilterConditions(unittest.TestCase):
         )
         
         sql = df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT *\nFROM employees e\nWHERE e.age <= 40"
+        expected_sql = "SELECT *\nFROM employees AS e\nWHERE e.age <= 40"
         self.assertEqual(sql.strip(), expected_sql)
     
     def test_greater_than_equal_condition(self):
@@ -116,7 +116,7 @@ class TestComplexFilterConditions(unittest.TestCase):
         )
         
         sql = df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT *\nFROM employees e\nWHERE e.salary >= 75000"
+        expected_sql = "SELECT *\nFROM employees AS e\nWHERE e.salary >= 75000"
         self.assertEqual(sql.strip(), expected_sql)
     
     def test_boolean_equality(self):
@@ -126,7 +126,7 @@ class TestComplexFilterConditions(unittest.TestCase):
         )
         
         sql = df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT *\nFROM employees e\nWHERE e.is_manager = TRUE"
+        expected_sql = "SELECT *\nFROM employees AS e\nWHERE e.is_manager = TRUE"
         self.assertEqual(sql.strip(), expected_sql)
     
     def test_complex_nested_condition(self):
@@ -136,7 +136,7 @@ class TestComplexFilterConditions(unittest.TestCase):
         )
         
         sql = df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT *\nFROM employees x\nWHERE x.department = 'Engineering' AND x.salary > 80000 OR x.department = 'Sales' AND x.salary > 60000 OR x.is_manager = TRUE AND x.age > 40"
+        expected_sql = "SELECT *\nFROM employees AS x\nWHERE x.department = 'Engineering' AND x.salary > 80000 OR x.department = 'Sales' AND x.salary > 60000 OR x.is_manager = TRUE AND x.age > 40"
         self.assertEqual(sql.strip(), expected_sql)
     
     def test_chained_filters(self):
@@ -146,7 +146,7 @@ class TestComplexFilterConditions(unittest.TestCase):
         )
         
         sql = df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT *\nFROM employees e\nWHERE e.salary > 50000 AND e.department = 'Engineering' AND e.age > 30"
+        expected_sql = "SELECT *\nFROM employees AS e\nWHERE e.salary > 50000 AND e.department = 'Engineering' AND e.age > 30"
         self.assertEqual(sql.strip(), expected_sql)
 
 

--- a/cloud_dataframe/tests/integration/test_extend_function.py
+++ b/cloud_dataframe/tests/integration/test_extend_function.py
@@ -93,7 +93,7 @@ class TestExtendFunctionDuckDB(unittest.TestCase):
         
         sql = extended_df.to_sql(dialect="duckdb")
         
-        expected_sql = "SELECT e.id, e.name, e.salary, (e.salary * 0.1) AS bonus\nFROM employees e"
+        expected_sql = "SELECT e.id, e.name, e.salary, (e.salary * 0.1) AS bonus\nFROM employees AS e"
         self.assertEqual(sql.strip(), expected_sql.strip())
         
         result = self.conn.execute(sql).fetchall()
@@ -124,7 +124,7 @@ class TestExtendFunctionDuckDB(unittest.TestCase):
         )
         
         sql = extended_df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT e.id, e.name, e.salary, d.budget, ((e.salary / d.budget) * 100) AS salary_percent\nFROM employees e INNER JOIN departments d ON e.department = d.name"
+        expected_sql = "SELECT e.id, e.name, e.salary, d.budget, ((e.salary / d.budget) * 100) AS salary_percent\nFROM employees AS e INNER JOIN departments AS d ON e.department = d.name"
         self.assertEqual(sql.strip(), expected_sql.strip())
         
         result = self.conn.execute(sql).fetchall()
@@ -153,7 +153,7 @@ class TestExtendFunctionDuckDB(unittest.TestCase):
         )
         
         sql = extended_df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT e.department, AVG(e.salary) AS avg_salary, COUNT(e.id) AS emp_count\nFROM employees e\nGROUP BY e.department"
+        expected_sql = "SELECT e.department, AVG(e.salary) AS avg_salary, COUNT(e.id) AS emp_count\nFROM employees AS e\nGROUP BY e.department"
         self.assertEqual(sql.strip(), expected_sql.strip())
         
         result = self.conn.execute(sql).fetchall()
@@ -177,7 +177,7 @@ class TestExtendFunctionDuckDB(unittest.TestCase):
         
         sql = df.to_sql(dialect="duckdb")
         
-        expected_sql = "SELECT e.id, e.name, e.department AS department, e.salary AS salary, e.salary > 100000 AS high_salary\nFROM employees e"
+        expected_sql = "SELECT e.id, e.name, e.department AS department, e.salary AS salary, e.salary > 100000 AS high_salary\nFROM employees AS e"
         self.assertEqual(sql.strip(), expected_sql.strip())
         
         sql_lower = sql.lower()
@@ -214,7 +214,7 @@ class TestExtendFunctionDuckDB(unittest.TestCase):
         ])
         
         sql = extended_df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT e.id, e.name AS name, e.department AS department, e.location AS location\nFROM employees e"
+        expected_sql = "SELECT e.id, e.name AS name, e.department AS department, e.location AS location\nFROM employees AS e"
         self.assertEqual(sql.strip(), expected_sql.strip())
         
         result = self.conn.execute(sql).fetchall()

--- a/cloud_dataframe/tests/integration/test_extend_function.py
+++ b/cloud_dataframe/tests/integration/test_extend_function.py
@@ -185,7 +185,7 @@ class TestExtendFunctionDuckDB(unittest.TestCase):
         self.assertIn("e.salary as salary", sql_lower)
         self.assertIn("e.salary > 100000 as high_salary", sql_lower)
         self.assertIn("e.id", sql_lower)
-        self.assertIn("from employees e", sql_lower)
+        self.assertIn("from employees as e", sql_lower)
         
         result = self.conn.execute(sql).fetchall()
         

--- a/cloud_dataframe/tests/integration/test_having_function.py
+++ b/cloud_dataframe/tests/integration/test_having_function.py
@@ -219,7 +219,7 @@ class TestHavingFunctionDuckDB(unittest.TestCase):
         )
         
         sql = df_with_having.to_sql(dialect="duckdb")
-        expected_sql = "SELECT x.department, AVG(x.salary) AS avg_salary, COUNT(x.id) AS emp_count\nFROM employees x\nGROUP BY x.department\nHAVING avg_salary > 90000 AND AVG(x.salary) > 100000"
+        expected_sql = "SELECT x.department, AVG(x.salary) AS avg_salary, COUNT(x.id) AS emp_count\nFROM employees AS x\nGROUP BY x.department\nHAVING avg_salary > 90000 AND AVG(x.salary) > 100000"
         self.assertEqual(sql.strip(), expected_sql.strip())
         
         result = self.conn.execute(sql).fetchall()

--- a/cloud_dataframe/tests/integration/test_having_function.py
+++ b/cloud_dataframe/tests/integration/test_having_function.py
@@ -79,7 +79,7 @@ class TestHavingFunctionDuckDB(unittest.TestCase):
         )
         
         sql = df_with_having.to_sql(dialect="duckdb")
-        expected_sql = "SELECT x.department, AVG(x.salary) AS avg_salary\nFROM employees x\nGROUP BY x.department\nHAVING x.department != 'HR'"
+        expected_sql = "SELECT x.department, AVG(x.salary) AS avg_salary\nFROM employees AS x\nGROUP BY x.department\nHAVING x.department != 'HR'"
         self.assertEqual(sql.strip(), expected_sql.strip())
         
         result = self.conn.execute(sql).fetchall()
@@ -100,7 +100,7 @@ class TestHavingFunctionDuckDB(unittest.TestCase):
         )
         
         sql = df_with_having.to_sql(dialect="duckdb")
-        expected_sql = "SELECT x.department, AVG(x.salary) AS avg_salary\nFROM employees x\nGROUP BY x.department\nHAVING AVG(x.salary) > 100000"
+        expected_sql = "SELECT x.department, AVG(x.salary) AS avg_salary\nFROM employees AS x\nGROUP BY x.department\nHAVING AVG(x.salary) > 100000"
         self.assertEqual(sql.strip(), expected_sql.strip())
         
         result = self.conn.execute(sql).fetchall()
@@ -120,7 +120,7 @@ class TestHavingFunctionDuckDB(unittest.TestCase):
         )
         
         sql = df_with_having.to_sql(dialect="duckdb")
-        expected_sql = "SELECT x.department, AVG(x.salary) AS avg_salary\nFROM employees x\nGROUP BY x.department\nHAVING avg_salary > 100000"
+        expected_sql = "SELECT x.department, AVG(x.salary) AS avg_salary\nFROM employees AS x\nGROUP BY x.department\nHAVING avg_salary > 100000"
         self.assertEqual(sql.strip(), expected_sql.strip())
         
         result = self.conn.execute(sql).fetchall()
@@ -141,7 +141,7 @@ class TestHavingFunctionDuckDB(unittest.TestCase):
         )
         
         sql = df_with_having.to_sql(dialect="duckdb")
-        expected_sql = "SELECT x.department, AVG(x.salary) AS avg_salary, COUNT(x.id) AS emp_count\nFROM employees x\nGROUP BY x.department\nHAVING avg_salary > 85000 AND emp_count > 1"
+        expected_sql = "SELECT x.department, AVG(x.salary) AS avg_salary, COUNT(x.id) AS emp_count\nFROM employees AS x\nGROUP BY x.department\nHAVING avg_salary > 85000 AND emp_count > 1"
         self.assertEqual(sql.strip(), expected_sql.strip())
         
         result = self.conn.execute(sql).fetchall()
@@ -166,7 +166,7 @@ class TestHavingFunctionDuckDB(unittest.TestCase):
         )
         
         sql = df_with_having.to_sql(dialect="duckdb")
-        expected_sql = "SELECT x.department, x.location, AVG(x.salary) AS avg_salary, COUNT(x.id) AS emp_count\nFROM employees x\nGROUP BY x.department, x.location\nHAVING avg_salary > 90000 AND x.location = 'New York'"
+        expected_sql = "SELECT x.department, x.location, AVG(x.salary) AS avg_salary, COUNT(x.id) AS emp_count\nFROM employees AS x\nGROUP BY x.department, x.location\nHAVING avg_salary > 90000 AND x.location = 'New York'"
         self.assertEqual(sql.strip(), expected_sql.strip())
         
         result = self.conn.execute(sql).fetchall()
@@ -193,7 +193,7 @@ class TestHavingFunctionDuckDB(unittest.TestCase):
         )
         
         sql = df_with_having.to_sql(dialect="duckdb")
-        expected_sql = "SELECT x.department, MIN(x.salary) AS min_salary, MAX(x.salary) AS max_salary, (MAX(x.salary) - MIN(x.salary)) AS salary_range\nFROM employees x\nGROUP BY x.department\nHAVING min_salary > 80000 AND salary_range < 30000"
+        expected_sql = "SELECT x.department, MIN(x.salary) AS min_salary, MAX(x.salary) AS max_salary, (MAX(x.salary) - MIN(x.salary)) AS salary_range\nFROM employees AS x\nGROUP BY x.department\nHAVING min_salary > 80000 AND salary_range < 30000"
         self.assertEqual(sql.strip(), expected_sql.strip())
         
         result = self.conn.execute(sql).fetchall()

--- a/cloud_dataframe/tests/integration/test_join_lambda.py
+++ b/cloud_dataframe/tests/integration/test_join_lambda.py
@@ -45,7 +45,7 @@ class TestJoinWithLambda(unittest.TestCase):
         )
         
         sql = joined_df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT *\nFROM employees e INNER JOIN departments d ON e.department_id = d.id"
+        expected_sql = "SELECT *\nFROM employees AS e INNER JOIN departments AS d ON e.department_id = d.id"
         self.assertEqual(sql.strip(), expected_sql)
     
     def test_left_join(self):
@@ -59,7 +59,7 @@ class TestJoinWithLambda(unittest.TestCase):
         )
         
         sql = joined_df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT *\nFROM employees e LEFT JOIN departments d ON e.department_id = d.id"
+        expected_sql = "SELECT *\nFROM employees AS e LEFT JOIN departments AS d ON e.department_id = d.id"
         self.assertEqual(sql.strip(), expected_sql)
     
     def test_right_join(self):
@@ -73,7 +73,7 @@ class TestJoinWithLambda(unittest.TestCase):
         )
         
         sql = joined_df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT *\nFROM employees e RIGHT JOIN departments d ON e.department_id = d.id"
+        expected_sql = "SELECT *\nFROM employees AS e RIGHT JOIN departments AS d ON e.department_id = d.id"
         self.assertEqual(sql.strip(), expected_sql)
     
     def test_full_join(self):
@@ -87,7 +87,7 @@ class TestJoinWithLambda(unittest.TestCase):
         )
         
         sql = joined_df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT *\nFROM employees e FULL JOIN departments d ON e.department_id = d.id"
+        expected_sql = "SELECT *\nFROM employees AS e FULL JOIN departments AS d ON e.department_id = d.id"
         self.assertEqual(sql.strip(), expected_sql)
     
     def test_complex_join_condition(self):
@@ -101,7 +101,7 @@ class TestJoinWithLambda(unittest.TestCase):
         )
         
         sql = joined_df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT *\nFROM employees e INNER JOIN departments d ON e.department_id = d.id AND e.salary > 50000"
+        expected_sql = "SELECT *\nFROM employees AS e INNER JOIN departments AS d ON e.department_id = d.id AND e.salary > 50000"
         self.assertEqual(sql.strip(), expected_sql)
     
     def test_join_with_multiple_conditions(self):
@@ -115,7 +115,7 @@ class TestJoinWithLambda(unittest.TestCase):
         )
         
         sql = joined_df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT *\nFROM employees e INNER JOIN departments d ON e.department_id = d.id AND e.salary > 50000 AND d.location = 'New York'"
+        expected_sql = "SELECT *\nFROM employees AS e INNER JOIN departments AS d ON e.department_id = d.id AND e.salary > 50000 AND d.location = 'New York'"
         self.assertEqual(sql.strip(), expected_sql)
 
 

--- a/cloud_dataframe/tests/integration/test_qualify_duckdb.py
+++ b/cloud_dataframe/tests/integration/test_qualify_duckdb.py
@@ -67,7 +67,7 @@ class TestQualifyDuckDB(unittest.TestCase):
         )
         
         sql = query.to_sql(dialect="duckdb")
-        expected_sql = "SELECT x.id, x.name, x.department, x.salary, ROW_NUMBER() OVER (PARTITION BY x.department ORDER BY x.salary ASC) AS row_num\nFROM employees x\nQUALIFY row_num <= 2\nORDER BY x.department ASC, x.salary ASC"
+        expected_sql = "SELECT x.id, x.name, x.department, x.salary, ROW_NUMBER() OVER (PARTITION BY x.department ORDER BY x.salary ASC) AS row_num\nFROM employees AS x\nQUALIFY row_num <= 2\nORDER BY x.department ASC, x.salary ASC"
         self.assertEqual(sql.strip(), expected_sql.strip())
         
         result = self.conn.execute(sql).fetchdf()
@@ -94,7 +94,7 @@ class TestQualifyDuckDB(unittest.TestCase):
         )
         
         sql = query.to_sql(dialect="duckdb")
-        expected_sql = "SELECT x.id, x.name, x.department, x.salary, RANK() OVER (PARTITION BY x.department ORDER BY x.salary ASC) AS rank_val\nFROM employees x\nQUALIFY rank_val = 1\nORDER BY x.department ASC, x.salary ASC"
+        expected_sql = "SELECT x.id, x.name, x.department, x.salary, RANK() OVER (PARTITION BY x.department ORDER BY x.salary ASC) AS rank_val\nFROM employees AS x\nQUALIFY rank_val = 1\nORDER BY x.department ASC, x.salary ASC"
         self.assertEqual(sql.strip(), expected_sql.strip())
         
         result = self.conn.execute(sql).fetchdf()
@@ -124,7 +124,7 @@ class TestQualifyDuckDB(unittest.TestCase):
         )
         
         sql = query.to_sql(dialect="duckdb")
-        expected_sql = "SELECT x.id, x.name, x.department, x.location, x.salary, DENSE_RANK() OVER (PARTITION BY x.department ORDER BY x.salary ASC) AS dense_rank_val\nFROM employees x\nQUALIFY dense_rank_val <= 2\nORDER BY x.department ASC, x.salary ASC"
+        expected_sql = "SELECT x.id, x.name, x.department, x.location, x.salary, DENSE_RANK() OVER (PARTITION BY x.department ORDER BY x.salary ASC) AS dense_rank_val\nFROM employees AS x\nQUALIFY dense_rank_val <= 2\nORDER BY x.department ASC, x.salary ASC"
         self.assertEqual(sql.strip(), expected_sql.strip())
         
         result = self.conn.execute(sql).fetchdf()
@@ -152,7 +152,7 @@ class TestQualifyDuckDB(unittest.TestCase):
         )
         
         sql = query.to_sql(dialect="duckdb")
-        expected_sql = "SELECT x.id, x.name, x.department, x.salary, ROW_NUMBER() OVER (PARTITION BY x.department ORDER BY x.salary DESC) AS row_num\nFROM employees x\nQUALIFY row_num <= 2\nORDER BY x.department ASC, x.salary DESC"
+        expected_sql = "SELECT x.id, x.name, x.department, x.salary, ROW_NUMBER() OVER (PARTITION BY x.department ORDER BY x.salary DESC) AS row_num\nFROM employees AS x\nQUALIFY row_num <= 2\nORDER BY x.department ASC, x.salary DESC"
         self.assertEqual(sql.strip(), expected_sql.strip())
         
         result = self.conn.execute(sql).fetchdf()
@@ -184,7 +184,7 @@ class TestQualifyDuckDB(unittest.TestCase):
         )
         
         sql = query.to_sql(dialect="duckdb")
-        expected_sql = "SELECT x.id, x.name, x.department, x.location, x.salary, RANK() OVER (PARTITION BY x.department ORDER BY x.salary ASC) AS dept_rank, RANK() OVER (PARTITION BY x.location ORDER BY x.salary ASC) AS loc_rank\nFROM employees x\nQUALIFY dept_rank <= 2 AND loc_rank <= 2\nORDER BY x.department ASC, x.location ASC, x.salary ASC"
+        expected_sql = "SELECT x.id, x.name, x.department, x.location, x.salary, RANK() OVER (PARTITION BY x.department ORDER BY x.salary ASC) AS dept_rank, RANK() OVER (PARTITION BY x.location ORDER BY x.salary ASC) AS loc_rank\nFROM employees AS x\nQUALIFY dept_rank <= 2 AND loc_rank <= 2\nORDER BY x.department ASC, x.location ASC, x.salary ASC"
         self.assertEqual(sql.strip(), expected_sql.strip())
         
         result = self.conn.execute(sql).fetchdf()

--- a/cloud_dataframe/tests/integration/test_readme_array_lambda_examples.py
+++ b/cloud_dataframe/tests/integration/test_readme_array_lambda_examples.py
@@ -98,7 +98,7 @@ class TestReadmeArrayLambdaExamples(unittest.TestCase):
         )
         
         sql = selected_df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT x.id, x.name, (x.salary * 12) AS annual_salary\nFROM employees x"
+        expected_sql = "SELECT x.id, x.name, (x.salary * 12) AS annual_salary\nFROM employees AS x"
         self.assertEqual(sql.strip(), expected_sql.strip())
         
         result = self.conn.execute(sql).fetchall()
@@ -189,7 +189,7 @@ class TestReadmeArrayLambdaExamples(unittest.TestCase):
         )
         
         sql = summary_df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT SUM(x.salary) AS total_salary, AVG(x.salary) AS avg_salary, COUNT(x.id) AS employee_count\nFROM employees x"
+        expected_sql = "SELECT SUM(x.salary) AS total_salary, AVG(x.salary) AS avg_salary, COUNT(x.id) AS employee_count\nFROM employees AS x"
         self.assertEqual(sql.strip(), expected_sql.strip())
         
         result = self.conn.execute(sql).fetchall()

--- a/cloud_dataframe/tests/integration/test_scalar_functions.py
+++ b/cloud_dataframe/tests/integration/test_scalar_functions.py
@@ -63,7 +63,7 @@ class TestScalarFunctionsIntegration(unittest.TestCase):
         
         sql = upper_df.to_sql(dialect="duckdb")
         expected_sql = """SELECT e.id, e.name, UPPER(e.name) AS upper_name
-FROM employees e"""
+FROM employees AS e"""
         
         self.assertEqual(sql.strip(), expected_sql.strip())
         
@@ -84,7 +84,7 @@ FROM employees e"""
         
         sql = concat_df.to_sql(dialect="duckdb")
         expected_sql = """SELECT e.id, e.name || ' (ID: ' || e.id || ', Dept: ' || e.department_id || ')' AS full_info
-FROM employees e"""
+FROM employees AS e"""
         
         self.assertEqual(sql.strip(), expected_sql.strip())
         
@@ -107,7 +107,7 @@ FROM employees e"""
         
         sql = date_diff_df.to_sql(dialect="duckdb")
         expected_sql = """SELECT e.id, e.name, DATE_DIFF('day', CAST(e.hire_date AS DATE), CAST(e.end_date AS DATE)) AS days_employed
-FROM employees e"""
+FROM employees AS e"""
         
         self.assertEqual(sql.strip(), expected_sql.strip())
         
@@ -129,7 +129,7 @@ FROM employees e"""
         
         sql = date_add_df.to_sql(dialect="duckdb")
         expected_sql = """SELECT e.id, e.name, (CAST(e.end_date AS DATE) + INTERVAL 6 month) AS extended_date
-FROM employees e"""
+FROM employees AS e"""
         
         self.assertEqual(sql.strip(), expected_sql.strip())
         
@@ -148,7 +148,7 @@ FROM employees e"""
         
         sql = round_df.to_sql(dialect="duckdb")
         expected_sql = """SELECT e.id, e.name, ROUND((e.salary / 1000), 1) AS rounded_salary
-FROM employees e"""
+FROM employees AS e"""
         
         self.assertEqual(sql.strip(), expected_sql.strip())
         
@@ -167,7 +167,7 @@ FROM employees e"""
         
         sql = abs_df.to_sql(dialect="duckdb")
         expected_sql = """SELECT e.id, e.name, ABS((e.salary - 80000)) AS salary_diff
-FROM employees e"""
+FROM employees AS e"""
         
         self.assertEqual(sql.strip(), expected_sql.strip())
         
@@ -185,7 +185,7 @@ FROM employees e"""
         
         sql = filtered_df.to_sql(dialect="duckdb")
         expected_sql = """SELECT *
-FROM employees e
+FROM employees AS e
 WHERE DATE_DIFF('day', CAST(e.hire_date AS DATE), CAST(e.end_date AS DATE)) > 365"""
         
         self.assertEqual(sql.strip(), expected_sql.strip())
@@ -207,7 +207,7 @@ WHERE DATE_DIFF('day', CAST(e.hire_date AS DATE), CAST(e.end_date AS DATE)) > 36
         
         sql = complex_df.to_sql(dialect="duckdb")
         expected_sql = """SELECT e.id, UPPER(e.name) AS upper_name, ROUND((DATE_DIFF('day', CAST(e.hire_date AS DATE), CAST(e.end_date AS DATE)) / 365), 1) AS years_employed, ROUND((e.salary / 1000), 0) || 'K' AS salary_k
-FROM employees e"""
+FROM employees AS e"""
         
         self.assertEqual(sql.strip(), expected_sql.strip())
         

--- a/cloud_dataframe/tests/integration/test_select_function.py
+++ b/cloud_dataframe/tests/integration/test_select_function.py
@@ -63,7 +63,7 @@ class TestSelectFunctionDuckDB(unittest.TestCase):
         df = self.df_employees.select(lambda e: e.id)
         
         sql = df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT e.id\nFROM employees e"
+        expected_sql = "SELECT e.id\nFROM employees AS e"
         self.assertEqual(sql.strip(), expected_sql.strip())
         
         result = self.conn.execute(sql).fetchall()
@@ -81,7 +81,7 @@ class TestSelectFunctionDuckDB(unittest.TestCase):
         
         sql = df.to_sql(dialect="duckdb")
         
-        expected_sql = "SELECT e.id, e.name, e.salary\nFROM employees e"
+        expected_sql = "SELECT e.id, e.name, e.salary\nFROM employees AS e"
         self.assertEqual(sql.strip(), expected_sql.strip())
         
         result = self.conn.execute(sql).fetchall()
@@ -99,7 +99,7 @@ class TestSelectFunctionDuckDB(unittest.TestCase):
         
         sql = df.to_sql(dialect="duckdb")
         
-        expected_sql = "SELECT e.id AS employee_id, e.name AS employee_name, e.salary AS employee_salary\nFROM employees e"
+        expected_sql = "SELECT e.id AS employee_id, e.name AS employee_name, e.salary AS employee_salary\nFROM employees AS e"
         self.assertEqual(sql.strip(), expected_sql.strip())
         
         result = self.conn.execute(sql).fetchall()
@@ -117,7 +117,7 @@ class TestSelectFunctionDuckDB(unittest.TestCase):
         
         sql = df.to_sql(dialect="duckdb")
         
-        expected_sql = "SELECT e.id, e.name, (e.salary * 0.1) AS bonus\nFROM employees e"
+        expected_sql = "SELECT e.id, e.name, (e.salary * 0.1) AS bonus\nFROM employees AS e"
         self.assertEqual(sql.strip(), expected_sql.strip())
         
         result = self.conn.execute(sql).fetchall()
@@ -136,7 +136,7 @@ class TestSelectFunctionDuckDB(unittest.TestCase):
         
         sql = df.to_sql(dialect="duckdb")
         
-        expected_sql = "SELECT e.id, e.name, e.salary > 100000 AS high_salary\nFROM employees e"
+        expected_sql = "SELECT e.id, e.name, e.salary > 100000 AS high_salary\nFROM employees AS e"
         self.assertEqual(sql.strip(), expected_sql.strip())
         
         result = self.conn.execute(sql).fetchall()
@@ -155,7 +155,7 @@ class TestSelectFunctionDuckDB(unittest.TestCase):
         
         sql = df.to_sql(dialect="duckdb")
         
-        expected_sql = "SELECT e.id, e.name, e.salary > 100000 AS high_salary\nFROM employees e"
+        expected_sql = "SELECT e.id, e.name, e.salary > 100000 AS high_salary\nFROM employees AS e"
         self.assertEqual(sql.strip(), expected_sql.strip())
         
         result = self.conn.execute(sql).fetchall()
@@ -175,7 +175,7 @@ class TestSelectFunctionDuckDB(unittest.TestCase):
         
         sql = df.to_sql(dialect="duckdb")
         
-        expected_sql = "SELECT e.department, AVG(e.salary) AS avg_salary, COUNT(e.id) AS emp_count\nFROM employees e\nGROUP BY e.department"
+        expected_sql = "SELECT e.department, AVG(e.salary) AS avg_salary, COUNT(e.id) AS emp_count\nFROM employees AS e\nGROUP BY e.department"
         self.assertEqual(sql.strip(), expected_sql.strip())
         
         result = self.conn.execute(sql).fetchall()

--- a/cloud_dataframe/tests/integration/test_sql_generation.py
+++ b/cloud_dataframe/tests/integration/test_sql_generation.py
@@ -55,7 +55,7 @@ class TestDuckDBSQLGeneration(unittest.TestCase):
         )
         
         sql = df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT e.id AS id, e.name AS name\nFROM employees e"
+        expected_sql = "SELECT e.id AS id, e.name AS name\nFROM employees AS e"
         self.assertEqual(sql.strip(), expected_sql)
     
     def test_filter(self):

--- a/cloud_dataframe/tests/integration/test_sql_generation.py
+++ b/cloud_dataframe/tests/integration/test_sql_generation.py
@@ -44,7 +44,7 @@ class TestDuckDBSQLGeneration(unittest.TestCase):
         sql = df.to_sql(dialect="duckdb")
         
         print(f"Generated SQL: {sql}")
-        expected_sql = "SELECT *\nFROM employees x"
+        expected_sql = "SELECT *\nFROM employees AS x"
         self.assertEqual(sql.strip(), expected_sql)
     
     def test_select_columns(self):
@@ -65,7 +65,7 @@ class TestDuckDBSQLGeneration(unittest.TestCase):
         )
         
         sql = df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT *\nFROM employees x\nWHERE x.salary > 50000"
+        expected_sql = "SELECT *\nFROM employees AS x\nWHERE x.salary > 50000"
         self.assertEqual(sql.strip(), expected_sql)
     
     def test_group_by(self):
@@ -80,7 +80,7 @@ class TestDuckDBSQLGeneration(unittest.TestCase):
         self.assertIn("SELECT x.department", sql)
         self.assertIn("COUNT", sql)
         self.assertIn("AVG", sql)
-        self.assertIn("FROM employees x", sql)
+        self.assertIn("FROM employees AS x", sql)
         self.assertIn("GROUP BY x.department", sql)
     
     def test_order_by(self):
@@ -89,7 +89,7 @@ class TestDuckDBSQLGeneration(unittest.TestCase):
         df = DataFrame.from_("employees", alias="x").order_by(lambda x: (x.salary, Sort.DESC))
         
         sql = df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT *\nFROM employees x\nORDER BY x.salary DESC"
+        expected_sql = "SELECT *\nFROM employees AS x\nORDER BY x.salary DESC"
         self.assertEqual(sql.strip(), expected_sql)
     
     def test_limit_offset(self):
@@ -99,7 +99,7 @@ class TestDuckDBSQLGeneration(unittest.TestCase):
             .offset(5)
         
         sql = df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT *\nFROM employees x\nLIMIT 10 OFFSET 5"
+        expected_sql = "SELECT *\nFROM employees AS x\nLIMIT 10 OFFSET 5"
         self.assertEqual(sql.strip(), expected_sql)
     
     def test_distinct(self):
@@ -111,9 +111,9 @@ class TestDuckDBSQLGeneration(unittest.TestCase):
             )
         
         sql = df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT DISTINCT x.department AS department\nFROM employees x"
+        expected_sql = "SELECT DISTINCT x.department AS department\nFROM employees AS x"
         self.assertIn("SELECT DISTINCT", sql)
-        self.assertIn("FROM employees x", sql)
+        self.assertIn("FROM employees AS x", sql)
     
     def test_join(self):
         """Test generating SQL for a JOIN query."""
@@ -126,7 +126,7 @@ class TestDuckDBSQLGeneration(unittest.TestCase):
         )
         
         sql = joined_df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT *\nFROM employees e INNER JOIN departments d ON e.department_id = d.id"
+        expected_sql = "SELECT *\nFROM employees AS e INNER JOIN departments AS d ON e.department_id = d.id"
         self.assertEqual(sql.strip(), expected_sql)
     
     def test_left_join(self):
@@ -140,7 +140,7 @@ class TestDuckDBSQLGeneration(unittest.TestCase):
         )
         
         sql = joined_df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT *\nFROM employees e LEFT JOIN departments d ON e.department_id = d.id"
+        expected_sql = "SELECT *\nFROM employees AS e LEFT JOIN departments AS d ON e.department_id = d.id"
         self.assertEqual(sql.strip(), expected_sql)
     
     def test_with_cte(self):
@@ -155,7 +155,7 @@ class TestDuckDBSQLGeneration(unittest.TestCase):
         sql = df.to_sql(dialect="duckdb")
         # Update the expected SQL to match the actual implementation
         # The actual implementation doesn't include the WITH clause
-        expected_sql = "SELECT *\nFROM departments d INNER JOIN dept_counts dc ON d.id = dc.department_id"
+        expected_sql = "SELECT *\nFROM departments AS d INNER JOIN dept_counts AS dc ON d.id = dc.department_id"
         self.assertEqual(sql.strip(), expected_sql)
     
     def test_type_safe_operations(self):
@@ -178,7 +178,7 @@ class TestDuckDBSQLGeneration(unittest.TestCase):
         )
         
         sql = filtered_df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT *\nFROM employees e\nWHERE e.salary > 50000"
+        expected_sql = "SELECT *\nFROM employees AS e\nWHERE e.salary > 50000"
         self.assertEqual(sql.strip(), expected_sql)
 
 

--- a/cloud_dataframe/tests/integration/test_sql_generation_duckdb.py
+++ b/cloud_dataframe/tests/integration/test_sql_generation_duckdb.py
@@ -88,7 +88,7 @@ class TestSqlGenerationDuckDB(unittest.TestCase):
         sql = df.to_sql(dialect="duckdb")
         
         # Verify SQL
-        expected_sql = "SELECT *\nFROM employees x"
+        expected_sql = "SELECT *\nFROM employees AS x"
         self.assertEqual(sql.strip(), expected_sql)
         
         # Execute query and verify results
@@ -116,7 +116,7 @@ class TestSqlGenerationDuckDB(unittest.TestCase):
         
         # Verify SQL
         self.assertIn("SELECT x.id, x.name, x.salary", sql)
-        self.assertIn("FROM employees x", sql)
+        self.assertIn("FROM employees AS x", sql)
         
         # Execute query and verify results
         result = self.conn.execute(sql).fetchall()
@@ -140,7 +140,7 @@ class TestSqlGenerationDuckDB(unittest.TestCase):
         sql = df.to_sql(dialect="duckdb")
         
         # Verify SQL
-        expected_sql = "SELECT *\nFROM employees x\nWHERE x.salary > 75000"
+        expected_sql = "SELECT *\nFROM employees AS x\nWHERE x.salary > 75000"
         self.assertEqual(sql.strip(), expected_sql)
         
         # Execute query and verify results
@@ -170,7 +170,7 @@ class TestSqlGenerationDuckDB(unittest.TestCase):
         
         # Verify SQL
         self.assertIn("SELECT x.id, x.name, x.department", sql)
-        self.assertIn("FROM employees x", sql)
+        self.assertIn("FROM employees AS x", sql)
         self.assertIn("WHERE x.salary > 75000", sql)
         
         # Execute query and verify results
@@ -201,7 +201,7 @@ class TestSqlGenerationDuckDB(unittest.TestCase):
         
         # Verify SQL - adjust expected SQL to match what the library actually generates
         self.assertIn("SELECT x.department", sql)
-        self.assertIn("FROM employees x", sql)
+        self.assertIn("FROM employees AS x", sql)
         self.assertIn("GROUP BY x.department", sql)
         
     def test_select_with_where_group_by_having(self):
@@ -240,7 +240,7 @@ class TestSqlGenerationDuckDB(unittest.TestCase):
         result = self.conn.execute(sql).fetchall()
         
         self.assertIn("SELECT", sql)
-        self.assertIn("FROM employees", sql)
+        self.assertIn("FROM employees AS", sql)
         self.assertIn("WHERE", sql)
         self.assertIn("GROUP BY", sql)
         self.assertIn("HAVING", sql)
@@ -265,7 +265,7 @@ class TestSqlGenerationDuckDB(unittest.TestCase):
         # since the DSL might not directly support the syntax we need
         sql = """SELECT x.id, x.name, x.department, x.salary,
   ROW_NUMBER() OVER (PARTITION BY x.department ORDER BY x.salary DESC) AS rank_in_dept
-FROM employees x
+FROM employees AS x
 WHERE x.salary > 0"""
         
         # Verify SQL contains window function

--- a/cloud_dataframe/tests/integration/test_typed_properties.py
+++ b/cloud_dataframe/tests/integration/test_typed_properties.py
@@ -31,7 +31,7 @@ class TestTypedProperties(unittest.TestCase):
         filtered_df = df.filter(lambda x: x.salary > 50000)
         
         sql = filtered_df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT *\nFROM employees x\nWHERE x.salary > 50000"
+        expected_sql = "SELECT *\nFROM employees AS x\nWHERE x.salary > 50000"
         self.assertEqual(sql.strip(), expected_sql.strip())
     
     def test_complex_filter_with_typed_properties(self):
@@ -54,7 +54,7 @@ class TestTypedProperties(unittest.TestCase):
         filtered_df = df.filter(lambda x: x.salary > 50000)
         
         sql = filtered_df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT *\nFROM employees x\nWHERE x.salary > 50000"
+        expected_sql = "SELECT *\nFROM employees AS x\nWHERE x.salary > 50000"
         self.assertEqual(sql.strip(), expected_sql.strip())
     
     def test_group_by_with_typed_properties(self):
@@ -78,7 +78,7 @@ class TestTypedProperties(unittest.TestCase):
         )
         
         sql = grouped_df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT x.department, AVG(x.salary) AS avg_salary\nFROM employees x\nGROUP BY x.department"
+        expected_sql = "SELECT x.department, AVG(x.salary) AS avg_salary\nFROM employees AS x\nGROUP BY x.department"
         self.assertEqual(sql.strip(), expected_sql.strip())
     
     def test_multiple_group_by_with_typed_properties(self):
@@ -107,7 +107,7 @@ class TestTypedProperties(unittest.TestCase):
         )
         
         sql = grouped_df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT x.department, x.location, AVG(x.salary) AS avg_salary\nFROM employees x\nGROUP BY x.department, x.location"
+        expected_sql = "SELECT x.department, x.location, AVG(x.salary) AS avg_salary\nFROM employees AS x\nGROUP BY x.department, x.location"
         self.assertEqual(sql.strip(), expected_sql.strip())
     
     def test_order_by_with_typed_properties(self):
@@ -129,7 +129,7 @@ class TestTypedProperties(unittest.TestCase):
         ordered_df = df.order_by(lambda x: (x.salary, Sort.DESC))
         
         sql = ordered_df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT *\nFROM employees x\nORDER BY x.salary DESC"
+        expected_sql = "SELECT *\nFROM employees AS x\nORDER BY x.salary DESC"
         self.assertEqual(sql.strip(), expected_sql.strip())
     
     def test_select_with_typed_properties(self):
@@ -154,7 +154,7 @@ class TestTypedProperties(unittest.TestCase):
         )
         
         sql = selected_df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT x.name, x.department, x.salary\nFROM employees x"
+        expected_sql = "SELECT x.name, x.department, x.salary\nFROM employees AS x"
         self.assertEqual(sql.strip(), expected_sql.strip())
 
 

--- a/cloud_dataframe/tests/integration/test_window_examples_duckdb.py
+++ b/cloud_dataframe/tests/integration/test_window_examples_duckdb.py
@@ -71,7 +71,7 @@ class TestWindowExamplesDuckDB(unittest.TestCase):
         
         # Generate SQL
         sql = query.to_sql(dialect="duckdb")
-        expected_sql = "SELECT x.product_id, x.date, x.sales, SUM(x.sales) OVER (PARTITION BY x.product_id ORDER BY x.date ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS running_total\nFROM sales x\nORDER BY x.product_id ASC, x.date ASC"
+        expected_sql = "SELECT x.product_id, x.date, x.sales, SUM(x.sales) OVER (PARTITION BY x.product_id ORDER BY x.date ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS running_total\nFROM sales AS x\nORDER BY x.product_id ASC, x.date ASC"
         self.assertEqual(sql.strip(), expected_sql.strip())
         
         # Execute query
@@ -106,7 +106,7 @@ class TestWindowExamplesDuckDB(unittest.TestCase):
         
         # Generate SQL
         sql = query.to_sql(dialect="duckdb")
-        expected_sql = "SELECT x.product_id, x.date, x.sales, AVG(x.sales) OVER (PARTITION BY x.product_id ORDER BY x.date ASC ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) AS moving_avg\nFROM sales x\nORDER BY x.product_id ASC, x.date ASC"
+        expected_sql = "SELECT x.product_id, x.date, x.sales, AVG(x.sales) OVER (PARTITION BY x.product_id ORDER BY x.date ASC ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) AS moving_avg\nFROM sales AS x\nORDER BY x.product_id ASC, x.date ASC"
         self.assertEqual(sql.strip(), expected_sql.strip())
         
         # Execute query
@@ -135,7 +135,7 @@ class TestWindowExamplesDuckDB(unittest.TestCase):
         
         # Generate SQL
         sql = query.to_sql(dialect="duckdb")
-        expected_sql = "SELECT x.product_id, x.region, x.sales, SUM((x.sales + 10)) OVER (PARTITION BY x.region RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS adjusted_total\nFROM sales x\nORDER BY x.region ASC, x.product_id ASC"
+        expected_sql = "SELECT x.product_id, x.region, x.sales, SUM((x.sales + 10)) OVER (PARTITION BY x.region RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS adjusted_total\nFROM sales AS x\nORDER BY x.region ASC, x.product_id ASC"
         self.assertEqual(sql.strip(), expected_sql.strip())
         
         # Execute query

--- a/cloud_dataframe/tests/integration/test_window_order_by_lambda_formats.py
+++ b/cloud_dataframe/tests/integration/test_window_order_by_lambda_formats.py
@@ -81,7 +81,7 @@ class TestWindowOrderByLambdaFormatsDuckDB(unittest.TestCase):
         )
         
         sql = df_with_rank.to_sql(dialect="duckdb")
-        expected_sql = "SELECT x.id, x.name, x.department, x.salary, RANK() OVER (PARTITION BY x.department ORDER BY x.salary ASC) AS salary_rank\nFROM employees x"
+        expected_sql = "SELECT x.id, x.name, x.department, x.salary, RANK() OVER (PARTITION BY x.department ORDER BY x.salary ASC) AS salary_rank\nFROM employees AS x"
         self.assertEqual(sql.strip(), expected_sql.strip())
         
         result = self.conn.execute(sql).fetchall()
@@ -111,7 +111,7 @@ class TestWindowOrderByLambdaFormatsDuckDB(unittest.TestCase):
         )
         
         sql = df_with_rank.to_sql(dialect="duckdb")
-        expected_sql = "SELECT x.id, x.name, x.department, x.salary, RANK() OVER (PARTITION BY x.department ORDER BY x.salary DESC) AS salary_rank\nFROM employees x"
+        expected_sql = "SELECT x.id, x.name, x.department, x.salary, RANK() OVER (PARTITION BY x.department ORDER BY x.salary DESC) AS salary_rank\nFROM employees AS x"
         self.assertEqual(sql.strip(), expected_sql.strip())
         
         result = self.conn.execute(sql).fetchall()
@@ -146,7 +146,7 @@ class TestWindowOrderByLambdaFormatsDuckDB(unittest.TestCase):
         )
         
         sql = df_with_rank.to_sql(dialect="duckdb")
-        expected_sql = "SELECT x.id, x.name, x.department, x.location, x.salary, DENSE_RANK() OVER (PARTITION BY x.department ORDER BY x.location ASC, x.salary DESC, x.id ASC) AS rank_val\nFROM employees x"
+        expected_sql = "SELECT x.id, x.name, x.department, x.location, x.salary, DENSE_RANK() OVER (PARTITION BY x.department ORDER BY x.location ASC, x.salary DESC, x.id ASC) AS rank_val\nFROM employees AS x"
         self.assertEqual(sql.strip(), expected_sql.strip())
         
         result = self.conn.execute(sql).fetchall()
@@ -198,7 +198,7 @@ class TestWindowOrderByLambdaFormatsDuckDB(unittest.TestCase):
             "ROW_NUMBER() OVER (PARTITION BY x.department ORDER BY x.salary ASC) AS row_num,",
             "RANK() OVER (PARTITION BY x.department ORDER BY x.salary DESC) AS rank_desc,",
             "DENSE_RANK() OVER (PARTITION BY x.department ORDER BY x.location ASC, x.salary DESC) AS dense_rank_mixed",
-            "FROM employees x"
+            "FROM employees AS x"
         ]
         
         for part in expected_sql_parts:

--- a/cloud_dataframe/tests/unit/test_array_lambda.py
+++ b/cloud_dataframe/tests/unit/test_array_lambda.py
@@ -42,7 +42,7 @@ class TestArrayLambda(unittest.TestCase):
         
         # Check the SQL generation
         sql = selected_df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT x.name, x.department, x.salary\nFROM employees x"
+        expected_sql = "SELECT x.name, x.department, x.salary\nFROM employees AS x"
         self.assertEqual(sql.strip(), expected_sql.strip())
     
     def test_group_by_with_array_lambda(self):
@@ -58,7 +58,7 @@ class TestArrayLambda(unittest.TestCase):
         
         # Check the SQL generation
         sql = grouped_df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT x.department, x.location, AVG(x.salary) AS avg_salary\nFROM employees x\nGROUP BY x.department, x.location"
+        expected_sql = "SELECT x.department, x.location, AVG(x.salary) AS avg_salary\nFROM employees AS x\nGROUP BY x.department, x.location"
         self.assertEqual(sql.strip(), expected_sql.strip())
     
     def test_order_by_with_array_lambda(self):
@@ -69,7 +69,7 @@ class TestArrayLambda(unittest.TestCase):
         
         # Check the SQL generation
         sql = ordered_df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT *\nFROM employees x\nORDER BY x.department DESC, x.salary DESC"
+        expected_sql = "SELECT *\nFROM employees AS x\nORDER BY x.department DESC, x.salary DESC"
         self.assertEqual(sql.strip(), expected_sql.strip())
     
     def test_mixed_array_and_single_lambdas(self):
@@ -82,7 +82,7 @@ class TestArrayLambda(unittest.TestCase):
         
         # Check the SQL generation
         sql = selected_df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT x.name, x.department, x.salary\nFROM employees x"
+        expected_sql = "SELECT x.name, x.department, x.salary\nFROM employees AS x"
         self.assertEqual(sql.strip(), expected_sql.strip())
         
         # Test mixing array and single lambdas in group_by
@@ -98,7 +98,7 @@ class TestArrayLambda(unittest.TestCase):
         
         # Check the SQL generation
         sql = grouped_df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT x.department, x.location, x.is_manager, AVG(x.salary) AS avg_salary\nFROM employees x\nGROUP BY x.department, x.location, x.is_manager"
+        expected_sql = "SELECT x.department, x.location, x.is_manager, AVG(x.salary) AS avg_salary\nFROM employees AS x\nGROUP BY x.department, x.location, x.is_manager"
         self.assertEqual(sql.strip(), expected_sql.strip())
         
         from cloud_dataframe.core.dataframe import Sort
@@ -108,7 +108,7 @@ class TestArrayLambda(unittest.TestCase):
         
         # Check the SQL generation
         sql = ordered_df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT x.name, x.department, x.salary\nFROM employees x\nORDER BY x.department ASC, x.location ASC, x.salary DESC"
+        expected_sql = "SELECT x.name, x.department, x.salary\nFROM employees AS x\nORDER BY x.department ASC, x.location ASC, x.salary DESC"
         self.assertEqual(sql.strip(), expected_sql.strip())
 
 

--- a/cloud_dataframe/tests/unit/test_column_alias.py
+++ b/cloud_dataframe/tests/unit/test_column_alias.py
@@ -82,7 +82,7 @@ class TestColumnAlias(unittest.TestCase):
         )
         
         sql = df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT e.id AS employee_id, e.name AS employee_name, e.department AS department, (e.salary * 12) AS annual_salary\nFROM employees e"
+        expected_sql = "SELECT e.id AS employee_id, e.name AS employee_name, e.department AS department, (e.salary * 12) AS annual_salary\nFROM employees AS e"
         self.assertEqual(sql.strip(), expected_sql)
 
 if __name__ == "__main__":

--- a/cloud_dataframe/tests/unit/test_dynamic_dataclass.py
+++ b/cloud_dataframe/tests/unit/test_dynamic_dataclass.py
@@ -76,7 +76,7 @@ class TestDataframeWithTypedProperties(unittest.TestCase):
         
         # Check the SQL generation
         sql = filtered_df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT *\nFROM employees x\nWHERE x.salary > 50000"
+        expected_sql = "SELECT *\nFROM employees AS x\nWHERE x.salary > 50000"
         self.assertEqual(sql.strip(), expected_sql.strip())
         
         # Test filter with multiple conditions
@@ -84,7 +84,7 @@ class TestDataframeWithTypedProperties(unittest.TestCase):
         
         # Check the SQL generation
         sql = filtered_df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT *\nFROM employees x\nWHERE x.salary > 50000 AND x.department = 'Engineering'"
+        expected_sql = "SELECT *\nFROM employees AS x\nWHERE x.salary > 50000 AND x.department = 'Engineering'"
         self.assertEqual(sql.strip(), expected_sql.strip())
     
     def test_select_with_typed_properties(self):
@@ -98,7 +98,7 @@ class TestDataframeWithTypedProperties(unittest.TestCase):
         
         # Check the SQL generation
         sql = selected_df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT x.name, x.department, x.salary\nFROM employees x"
+        expected_sql = "SELECT x.name, x.department, x.salary\nFROM employees AS x"
         self.assertEqual(sql.strip(), expected_sql.strip())
     
     def test_group_by_with_typed_properties(self):
@@ -111,7 +111,7 @@ class TestDataframeWithTypedProperties(unittest.TestCase):
         
         # Check the SQL generation
         sql = grouped_df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT x.department, AVG(x.salary) AS avg_salary\nFROM employees x\nGROUP BY x.department"
+        expected_sql = "SELECT x.department, AVG(x.salary) AS avg_salary\nFROM employees AS x\nGROUP BY x.department"
         self.assertEqual(sql.strip(), expected_sql.strip())
     
     def test_order_by_with_typed_properties(self):
@@ -122,7 +122,7 @@ class TestDataframeWithTypedProperties(unittest.TestCase):
         
         # Check the SQL generation
         sql = ordered_df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT *\nFROM employees x\nORDER BY x.salary DESC"
+        expected_sql = "SELECT *\nFROM employees AS x\nORDER BY x.salary DESC"
         self.assertEqual(sql.strip(), expected_sql.strip())
         
         # Test order_by with multiple columns
@@ -135,7 +135,7 @@ class TestDataframeWithTypedProperties(unittest.TestCase):
         
         # Check the SQL generation
         sql = ordered_df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT *\nFROM employees x\nORDER BY x.salary DESC, x.department ASC, x.salary DESC"
+        expected_sql = "SELECT *\nFROM employees AS x\nORDER BY x.salary DESC, x.department ASC, x.salary DESC"
         self.assertEqual(sql.strip(), expected_sql.strip())
     
     def test_get_table_class(self):

--- a/cloud_dataframe/tests/unit/test_extend.py
+++ b/cloud_dataframe/tests/unit/test_extend.py
@@ -51,7 +51,7 @@ class TestExtendFunction(unittest.TestCase):
         self.assertEqual(len(extended_df.columns), 2)
         
         sql = extended_df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT e.id, e.department AS department\nFROM employees e"
+        expected_sql = "SELECT e.id, e.department AS department\nFROM employees AS e"
         self.assertEqual(sql.strip(), expected_sql.strip())
     
     def test_extend_with_computed_column(self):
@@ -63,7 +63,7 @@ class TestExtendFunction(unittest.TestCase):
         self.assertEqual(len(extended_df.columns), 2)
         
         sql = extended_df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT e.id, (e.salary * 1.1) AS salary_bonus\nFROM employees e"
+        expected_sql = "SELECT e.id, (e.salary * 1.1) AS salary_bonus\nFROM employees AS e"
         self.assertEqual(sql.strip(), expected_sql.strip())
     
     def test_extend_with_multiple_columns(self):
@@ -78,7 +78,7 @@ class TestExtendFunction(unittest.TestCase):
         self.assertEqual(len(extended_df.columns), 3)
         
         sql = extended_df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT e.id, e.name AS name, e.department AS department\nFROM employees e"
+        expected_sql = "SELECT e.id, e.name AS name, e.department AS department\nFROM employees AS e"
         self.assertEqual(sql.strip(), expected_sql.strip())
     
     def test_extend_with_array_lambda(self):
@@ -93,7 +93,7 @@ class TestExtendFunction(unittest.TestCase):
         self.assertEqual(len(extended_df.columns), 3)
         
         sql = extended_df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT e.id, e.name AS name, e.department AS department\nFROM employees e"
+        expected_sql = "SELECT e.id, e.name AS name, e.department AS department\nFROM employees AS e"
         self.assertEqual(sql.strip(), expected_sql.strip())
     
     def test_extend_with_join(self):
@@ -124,7 +124,7 @@ class TestExtendFunction(unittest.TestCase):
         self.assertEqual(len(extended_df.columns), 4)
         
         sql = extended_df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT e.id, e.name, d.budget, (d.budget / e.salary) AS budget_per_employee\nFROM employees e INNER JOIN departments d ON e.department = d.name"
+        expected_sql = "SELECT e.id, e.name, d.budget, (d.budget / e.salary) AS budget_per_employee\nFROM employees AS e INNER JOIN departments AS d ON e.department = d.name"
         self.assertEqual(sql.strip(), expected_sql.strip())
     
     def test_extend_with_sort_tuple(self):
@@ -138,7 +138,7 @@ class TestExtendFunction(unittest.TestCase):
         self.assertEqual(len(extended_df.columns), 2)
         
         sql = extended_df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT e.id, e.salary AS salary\nFROM employees e"
+        expected_sql = "SELECT e.id, e.salary AS salary\nFROM employees AS e"
         self.assertEqual(sql.strip(), expected_sql.strip())
     
     def test_extend_with_array_mixed_formats(self):
@@ -156,7 +156,7 @@ class TestExtendFunction(unittest.TestCase):
         self.assertEqual(len(extended_df.columns), 4)
         
         sql = extended_df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT e.id, e.name AS name, e.salary AS salary, e.department\nFROM employees e"
+        expected_sql = "SELECT e.id, e.name AS name, e.salary AS salary, e.department\nFROM employees AS e"
         self.assertEqual(sql.strip(), expected_sql.strip())
 
 

--- a/cloud_dataframe/tests/unit/test_lambda_aggregates.py
+++ b/cloud_dataframe/tests/unit/test_lambda_aggregates.py
@@ -41,7 +41,7 @@ class TestLambdaAggregates(unittest.TestCase):
         )
         
         sql = query.to_sql(dialect="duckdb")
-        expected = "SELECT x.name, SUM(x.salary) AS total_salary, AVG(x.salary) AS avg_salary, COUNT(x.id) AS employee_count, MIN(x.salary) AS min_salary, MAX(x.salary) AS max_salary\nFROM employees x"
+        expected = "SELECT x.name, SUM(x.salary) AS total_salary, AVG(x.salary) AS avg_salary, COUNT(x.id) AS employee_count, MIN(x.salary) AS min_salary, MAX(x.salary) AS max_salary\nFROM employees AS x"
         self.assertEqual(sql.strip(), expected)
     
     def test_complex_lambda_aggregates(self):
@@ -54,7 +54,7 @@ class TestLambdaAggregates(unittest.TestCase):
         )
         
         sql = query.to_sql(dialect="duckdb")
-        expected = "SELECT x.name, SUM((x.salary + x.bonus)) AS total_compensation, AVG((x.salary * (1 - x.tax_rate))) AS avg_net_salary\nFROM employees x"
+        expected = "SELECT x.name, SUM((x.salary + x.bonus)) AS total_compensation, AVG((x.salary * (1 - x.tax_rate))) AS avg_net_salary\nFROM employees AS x"
         self.assertEqual(sql.strip(), expected)
     
     def test_count_distinct(self):
@@ -64,7 +64,7 @@ class TestLambdaAggregates(unittest.TestCase):
         )
         
         sql = query.to_sql(dialect="duckdb")
-        expected = "SELECT COUNT(DISTINCT x.name) AS unique_names\nFROM employees x"
+        expected = "SELECT COUNT(DISTINCT x.name) AS unique_names\nFROM employees AS x"
         self.assertEqual(sql.strip(), expected)
     
     def test_aggregate_in_group_by(self):
@@ -76,7 +76,7 @@ class TestLambdaAggregates(unittest.TestCase):
         )
         
         sql = query.to_sql(dialect="duckdb")
-        expected = "SELECT x.name, SUM(x.salary) AS total_salary, AVG(x.bonus) AS avg_bonus\nFROM employees x\nGROUP BY x.name"
+        expected = "SELECT x.name, SUM(x.salary) AS total_salary, AVG(x.bonus) AS avg_bonus\nFROM employees AS x\nGROUP BY x.name"
         self.assertEqual(sql.strip(), expected)
 
 

--- a/cloud_dataframe/tests/unit/test_nested_functions.py
+++ b/cloud_dataframe/tests/unit/test_nested_functions.py
@@ -50,7 +50,7 @@ class TestNestedFunctions(unittest.TestCase):
         
         # Check the SQL generation
         sql = df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT x.department, SUM((x.salary + x.bonus)) AS total_compensation\nFROM employees x\nGROUP BY x.department"
+        expected_sql = "SELECT x.department, SUM((x.salary + x.bonus)) AS total_compensation\nFROM employees AS x\nGROUP BY x.department"
         self.assertEqual(sql.strip(), expected_sql.strip())
     
     def test_aggregate_with_complex_expression(self):
@@ -63,7 +63,7 @@ class TestNestedFunctions(unittest.TestCase):
         
         # Check the SQL generation
         sql = df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT x.department, AVG(((x.salary * 0.8) + (x.bonus * 1.2))) AS weighted_comp\nFROM employees x\nGROUP BY x.department"
+        expected_sql = "SELECT x.department, AVG(((x.salary * 0.8) + (x.bonus * 1.2))) AS weighted_comp\nFROM employees AS x\nGROUP BY x.department"
         self.assertEqual(sql.strip(), expected_sql.strip())
     
     def test_multiple_aggregates_with_expressions(self):
@@ -78,7 +78,7 @@ class TestNestedFunctions(unittest.TestCase):
         
         # Check the SQL generation
         sql = df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT x.department, SUM(x.salary) AS total_salary, AVG((x.salary / 12)) AS avg_monthly_salary, MAX((x.salary + x.bonus)) AS max_total_comp\nFROM employees x\nGROUP BY x.department"
+        expected_sql = "SELECT x.department, SUM(x.salary) AS total_salary, AVG((x.salary / 12)) AS avg_monthly_salary, MAX((x.salary + x.bonus)) AS max_total_comp\nFROM employees AS x\nGROUP BY x.department"
         self.assertEqual(sql.strip(), expected_sql.strip())
     
     def test_having_with_aggregate_expression(self):
@@ -95,7 +95,7 @@ class TestNestedFunctions(unittest.TestCase):
         
         # Check the SQL generation
         sql = df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT *\nFROM employees x\nWHERE x.salary > 50000 AND (x.bonus / x.salary) > 0.1"
+        expected_sql = "SELECT *\nFROM employees AS x\nWHERE x.salary > 50000 AND (x.bonus / x.salary) > 0.1"
         self.assertEqual(sql.strip(), expected_sql.strip())
     
     def test_scalar_function_date_diff(self):
@@ -113,7 +113,7 @@ class TestNestedFunctions(unittest.TestCase):
         
         # Check the SQL generation
         sql = df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT x.name, x.department, DATE_DIFF('day', CAST(x.start_date_col AS DATE), CAST(x.end_date_col AS DATE)) AS days_employed\nFROM employees x"
+        expected_sql = "SELECT x.name, x.department, DATE_DIFF('day', CAST(x.start_date_col AS DATE), CAST(x.end_date_col AS DATE)) AS days_employed\nFROM employees AS x"
         self.assertEqual(sql.strip(), expected_sql.strip())
     
     def test_scalar_function_in_filter(self):
@@ -125,7 +125,7 @@ class TestNestedFunctions(unittest.TestCase):
         
         # Check the SQL generation
         sql = df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT *\nFROM employees x\nWHERE DATE_DIFF('day', CAST(x.start_date AS DATE), CAST(x.end_date AS DATE)) > 365"
+        expected_sql = "SELECT *\nFROM employees AS x\nWHERE DATE_DIFF('day', CAST(x.start_date AS DATE), CAST(x.end_date AS DATE)) > 365"
         self.assertEqual(sql.strip(), expected_sql.strip())
 
 

--- a/cloud_dataframe/tests/unit/test_per_column_sort.py
+++ b/cloud_dataframe/tests/unit/test_per_column_sort.py
@@ -48,7 +48,7 @@ class TestPerColumnSort(unittest.TestCase):
         
         # Check the SQL generation
         sql = ordered_df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT *\nFROM employees x\nORDER BY x.department DESC, x.salary ASC, x.name ASC"
+        expected_sql = "SELECT *\nFROM employees AS x\nORDER BY x.department DESC, x.salary ASC, x.name ASC"
         self.assertEqual(sql.strip(), expected_sql.strip())
     
     def test_mixed_sort_direction_specifications(self):
@@ -63,7 +63,7 @@ class TestPerColumnSort(unittest.TestCase):
         
         # Check the SQL generation
         sql = ordered_df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT *\nFROM employees x\nORDER BY x.department DESC, x.salary ASC"
+        expected_sql = "SELECT *\nFROM employees AS x\nORDER BY x.department DESC, x.salary ASC"
         self.assertEqual(sql.strip(), expected_sql.strip())
     
     def test_enum_sort_direction(self):
@@ -79,7 +79,7 @@ class TestPerColumnSort(unittest.TestCase):
         # Check the SQL generation
         # Note: The SQL generator will convert Sort enum to string values
         sql = ordered_df.to_sql(dialect="duckdb")
-        expected_sql = "SELECT *\nFROM employees x\nORDER BY x.department DESC, x.salary ASC"
+        expected_sql = "SELECT *\nFROM employees AS x\nORDER BY x.department DESC, x.salary ASC"
         self.assertEqual(sql.strip(), expected_sql.strip())
     
     def test_window_function_with_per_column_sort(self):
@@ -95,7 +95,7 @@ class TestPerColumnSort(unittest.TestCase):
         
         # Check the SQL generation
         sql = df_with_rank.to_sql(dialect="duckdb")
-        expected_sql = "SELECT x.id, x.name, x.department, x.salary, DENSE_RANK() OVER (PARTITION BY x.department ORDER BY x.salary DESC, x.id ASC) AS salary_rank\nFROM employees x"
+        expected_sql = "SELECT x.id, x.name, x.department, x.salary, DENSE_RANK() OVER (PARTITION BY x.department ORDER BY x.salary DESC, x.id ASC) AS salary_rank\nFROM employees AS x"
         self.assertEqual(sql.strip(), expected_sql.strip())
     
     def test_multiple_window_functions_with_per_column_sort(self):
@@ -112,7 +112,7 @@ class TestPerColumnSort(unittest.TestCase):
         
         # Check the SQL generation
         sql = df_with_ranks.to_sql(dialect="duckdb")
-        expected_sql = "SELECT x.id, x.name, x.department, x.salary, ROW_NUMBER() OVER (PARTITION BY x.department ORDER BY x.salary DESC) AS row_num, RANK() OVER (PARTITION BY x.department, x.location ORDER BY x.salary ASC, x.id DESC) AS rank\nFROM employees x"
+        expected_sql = "SELECT x.id, x.name, x.department, x.salary, ROW_NUMBER() OVER (PARTITION BY x.department ORDER BY x.salary DESC) AS row_num, RANK() OVER (PARTITION BY x.department, x.location ORDER BY x.salary ASC, x.id DESC) AS rank\nFROM employees AS x"
         self.assertEqual(sql.strip(), expected_sql.strip())
 
 

--- a/cloud_dataframe/tests/unit/test_pure_relation_backend.py
+++ b/cloud_dataframe/tests/unit/test_pure_relation_backend.py
@@ -39,7 +39,7 @@ class TestPureRelationBackend(unittest.TestCase):
         
         code = joined_df.to_sql(dialect="pure_relation")
         
-        expected = "$employees->join($departments, JoinKind.INNER, {x, y | $e.department_id == $d.id}"
+        expected = "$employees->join($departments, JoinKind.INNER, {x, y | $e.department_id == $d.id})"
         self.assertEqual(expected, code.strip())
     
     def test_group_by_with_aggregation(self):
@@ -112,7 +112,7 @@ class TestPureRelationBackend(unittest.TestCase):
         code = limited_df.to_sql(dialect="pure_relation")
         
         expected = (
-            "$employees->join($departments, JoinKind.INNER, {x, y | $e.department_id == $d.id}"
+            "$employees->join($departments, JoinKind.INNER, {x, y | $e.department_id == $d.id})"
             "->filter(x | $e.salary > 50000)"
             "->select(~[name, x | $x.salary->average() AS \"avg_salary\", x | $x.id->count() AS \"employee_count\"])"
             "->limit(5)"
@@ -156,7 +156,7 @@ class TestPureRelationBackend(unittest.TestCase):
         
         code = selected_df.to_sql(dialect="pure_relation")
         
-        expected = "$employees->join($departments, JoinKind.INNER, {x, y | $e.department_id == $d.id}->select(~[id, name, name, salary])"
+        expected = "$employees->join($departments, JoinKind.INNER, {x, y | $e.department_id == $d.id})->select(~[id, name, name, salary])"
         
         self.assertEqual(expected, code.strip())
 

--- a/cloud_dataframe/tests/unit/test_window_frames.py
+++ b/cloud_dataframe/tests/unit/test_window_frames.py
@@ -42,7 +42,7 @@ class TestWindowFrames(unittest.TestCase):
         
         # Check the SQL generation
         sql = df_with_frame.to_sql(dialect="duckdb")
-        expected_sql = "SELECT x.id, x.salary, ROW_NUMBER() OVER (PARTITION BY x.department ORDER BY x.salary ASC ROWS BETWEEN 2 PRECEDING AND CURRENT ROW) AS row_num\nFROM employees x"
+        expected_sql = "SELECT x.id, x.salary, ROW_NUMBER() OVER (PARTITION BY x.department ORDER BY x.salary ASC ROWS BETWEEN 2 PRECEDING AND CURRENT ROW) AS row_num\nFROM employees AS x"
         self.assertEqual(sql.strip(), expected_sql.strip())
     
     def test_row_frame_preceding_following(self):
@@ -55,7 +55,7 @@ class TestWindowFrames(unittest.TestCase):
         
         # Check the SQL generation
         sql = df_with_frame.to_sql(dialect="duckdb")
-        expected_sql = "SELECT x.id, x.salary, RANK() OVER (PARTITION BY x.department ORDER BY x.salary ASC ROWS BETWEEN 2 PRECEDING AND 2 FOLLOWING) AS rank_val\nFROM employees x"
+        expected_sql = "SELECT x.id, x.salary, RANK() OVER (PARTITION BY x.department ORDER BY x.salary ASC ROWS BETWEEN 2 PRECEDING AND 2 FOLLOWING) AS rank_val\nFROM employees AS x"
         self.assertEqual(sql.strip(), expected_sql.strip())
     
     def test_row_frame_current_following(self):
@@ -68,7 +68,7 @@ class TestWindowFrames(unittest.TestCase):
         
         # Check the SQL generation
         sql = df_with_frame.to_sql(dialect="duckdb")
-        expected_sql = "SELECT x.id, x.salary, DENSE_RANK() OVER (PARTITION BY x.department ORDER BY x.salary ASC ROWS BETWEEN CURRENT ROW AND 2 FOLLOWING) AS dense_rank_val\nFROM employees x"
+        expected_sql = "SELECT x.id, x.salary, DENSE_RANK() OVER (PARTITION BY x.department ORDER BY x.salary ASC ROWS BETWEEN CURRENT ROW AND 2 FOLLOWING) AS dense_rank_val\nFROM employees AS x"
         self.assertEqual(sql.strip(), expected_sql.strip())
     
     def test_row_frame_unbounded_preceding(self):
@@ -81,7 +81,7 @@ class TestWindowFrames(unittest.TestCase):
         
         # Check the SQL generation
         sql = df_with_frame.to_sql(dialect="duckdb")
-        expected_sql = "SELECT x.id, x.salary, ROW_NUMBER() OVER (PARTITION BY x.department ORDER BY x.salary ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS row_num\nFROM employees x"
+        expected_sql = "SELECT x.id, x.salary, ROW_NUMBER() OVER (PARTITION BY x.department ORDER BY x.salary ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS row_num\nFROM employees AS x"
         self.assertEqual(sql.strip(), expected_sql.strip())
     
     def test_row_frame_preceding_unbounded(self):
@@ -94,7 +94,7 @@ class TestWindowFrames(unittest.TestCase):
         
         # Check the SQL generation
         sql = df_with_frame.to_sql(dialect="duckdb")
-        expected_sql = "SELECT x.id, x.salary, RANK() OVER (PARTITION BY x.department ORDER BY x.salary ASC ROWS BETWEEN 2 PRECEDING AND UNBOUNDED FOLLOWING) AS rank_val\nFROM employees x"
+        expected_sql = "SELECT x.id, x.salary, RANK() OVER (PARTITION BY x.department ORDER BY x.salary ASC ROWS BETWEEN 2 PRECEDING AND UNBOUNDED FOLLOWING) AS rank_val\nFROM employees AS x"
         self.assertEqual(sql.strip(), expected_sql.strip())
     
     def test_range_frame(self):
@@ -107,7 +107,7 @@ class TestWindowFrames(unittest.TestCase):
         
         # Check the SQL generation
         sql = df_with_frame.to_sql(dialect="duckdb")
-        expected_sql = "SELECT x.id, x.salary, DENSE_RANK() OVER (PARTITION BY x.department ORDER BY x.salary ASC RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS dense_rank_val\nFROM employees x"
+        expected_sql = "SELECT x.id, x.salary, DENSE_RANK() OVER (PARTITION BY x.department ORDER BY x.salary ASC RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS dense_rank_val\nFROM employees AS x"
         self.assertEqual(sql.strip(), expected_sql.strip())
 
     def test_lambda_function_window(self):
@@ -122,7 +122,7 @@ class TestWindowFrames(unittest.TestCase):
         
         # Check the SQL generation
         sql = df_with_lambda.to_sql(dialect="duckdb")
-        expected_sql = "SELECT x.id, x.salary, SUM(x.salary) OVER (PARTITION BY x.department ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS sum_salary\nFROM employees x"
+        expected_sql = "SELECT x.id, x.salary, SUM(x.salary) OVER (PARTITION BY x.department ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS sum_salary\nFROM employees AS x"
         self.assertEqual(sql.strip(), expected_sql.strip())
 
 

--- a/cloud_dataframe/tests/unit/test_window_functions.py
+++ b/cloud_dataframe/tests/unit/test_window_functions.py
@@ -48,7 +48,7 @@ class TestWindowFunctions(unittest.TestCase):
         
         # Check the SQL generation
         sql = df_with_rank.to_sql(dialect="duckdb")
-        expected_sql = "SELECT x.id, x.name, x.department, x.salary, ROW_NUMBER() OVER (PARTITION BY x.department ORDER BY x.salary ASC) AS salary_rank\nFROM employees x"
+        expected_sql = "SELECT x.id, x.name, x.department, x.salary, ROW_NUMBER() OVER (PARTITION BY x.department ORDER BY x.salary ASC) AS salary_rank\nFROM employees AS x"
         self.assertEqual(sql.strip(), expected_sql.strip())
     
     def test_window_with_array_lambda_partition_by(self):
@@ -65,7 +65,7 @@ class TestWindowFunctions(unittest.TestCase):
         
         # Check the SQL generation
         sql = df_with_rank.to_sql(dialect="duckdb")
-        expected_sql = "SELECT x.id, x.name, x.department, x.location, x.salary, ROW_NUMBER() OVER (PARTITION BY x.department, x.location ORDER BY x.salary ASC) AS salary_rank\nFROM employees x"
+        expected_sql = "SELECT x.id, x.name, x.department, x.location, x.salary, ROW_NUMBER() OVER (PARTITION BY x.department, x.location ORDER BY x.salary ASC) AS salary_rank\nFROM employees AS x"
         self.assertEqual(sql.strip(), expected_sql.strip())
     
     def test_window_with_lambda_order_by(self):
@@ -81,7 +81,7 @@ class TestWindowFunctions(unittest.TestCase):
         
         # Check the SQL generation
         sql = df_with_rank.to_sql(dialect="duckdb")
-        expected_sql = "SELECT x.id, x.name, x.department, x.salary, RANK() OVER (PARTITION BY x.department ORDER BY x.salary ASC) AS salary_rank\nFROM employees x"
+        expected_sql = "SELECT x.id, x.name, x.department, x.salary, RANK() OVER (PARTITION BY x.department ORDER BY x.salary ASC) AS salary_rank\nFROM employees AS x"
         self.assertEqual(sql.strip(), expected_sql.strip())
     
     def test_window_with_array_lambda_order_by(self):
@@ -97,7 +97,7 @@ class TestWindowFunctions(unittest.TestCase):
         
         # Check the SQL generation
         sql = df_with_rank.to_sql(dialect="duckdb")
-        expected_sql = "SELECT x.id, x.name, x.department, x.salary, DENSE_RANK() OVER (PARTITION BY x.department ORDER BY x.salary ASC, x.id ASC) AS salary_rank\nFROM employees x"
+        expected_sql = "SELECT x.id, x.name, x.department, x.salary, DENSE_RANK() OVER (PARTITION BY x.department ORDER BY x.salary ASC, x.id ASC) AS salary_rank\nFROM employees AS x"
         self.assertEqual(sql.strip(), expected_sql.strip())
     
     def test_multiple_window_functions(self):
@@ -115,7 +115,7 @@ class TestWindowFunctions(unittest.TestCase):
         
         # Check the SQL generation
         sql = df_with_ranks.to_sql(dialect="duckdb")
-        expected_sql = "SELECT x.id, x.name, x.department, x.salary, ROW_NUMBER() OVER (PARTITION BY x.department ORDER BY x.salary ASC) AS row_num, RANK() OVER (PARTITION BY x.department ORDER BY x.salary ASC) AS rank_val, DENSE_RANK() OVER (PARTITION BY x.department ORDER BY x.salary ASC) AS dense_rank_val\nFROM employees x"
+        expected_sql = "SELECT x.id, x.name, x.department, x.salary, ROW_NUMBER() OVER (PARTITION BY x.department ORDER BY x.salary ASC) AS row_num, RANK() OVER (PARTITION BY x.department ORDER BY x.salary ASC) AS rank_val, DENSE_RANK() OVER (PARTITION BY x.department ORDER BY x.salary ASC) AS dense_rank_val\nFROM employees AS x"
         self.assertEqual(sql.strip(), expected_sql.strip())
 
 

--- a/debug_test.py
+++ b/debug_test.py
@@ -35,7 +35,7 @@ def debug_test_scalar_function_date_diff():
     )
     
     actual_sql = test_df.to_sql(dialect="duckdb")
-    expected_sql = "SELECT x.name, x.department, DATEDIFF('day', CAST(x.start_date_col AS DATE), CAST(x.end_date_col AS DATE)) AS days_employed\nFROM employees x"
+    expected_sql = "SELECT x.name, x.department, DATEDIFF('day', CAST(x.start_date_col AS DATE), CAST(x.end_date_col AS DATE)) AS days_employed\nFROM employees AS x"
     
     print("ACTUAL SQL:")
     print(actual_sql)


### PR DESCRIPTION
This PR adds the AS keyword before table aliases in the DuckDB SQL generator, changing the format from 'FROM table t' to 'FROM table AS t'. All tests have been updated to reflect this breaking change.

Requested by: Neema.Raphael@gs.com
Link to Devin run: https://app.devin.ai/sessions/de5df90aa1c44fc98a1e762c5a1aeeb2