### PR TITLE
Fix Pure code generator to remove AS clauses in pure relation syntax

### DIFF
--- a/cloud_dataframe/backends/pure_relation/generator.py
+++ b/cloud_dataframe/backends/pure_relation/generator.py
@@ -156,11 +156,14 @@ def _apply_select(relation_code: str, columns: List[Column]) -> str:
     cols = []
     for col in columns:
         if isinstance(col, Column):
-            expr = col.expression
-            if isinstance(expr, ColumnReference):
-                cols.append(expr.name)
+            if col.alias:
+                cols.append(col.alias)
             else:
-                cols.append(_generate_expression(expr))
+                expr = col.expression
+                if isinstance(expr, ColumnReference):
+                    cols.append(expr.name)
+                else:
+                    cols.append(_generate_expression(expr))
         elif isinstance(col, ColumnReference):
             cols.append(col.name)
         else:
@@ -309,6 +312,9 @@ def _generate_expression(expr: Any) -> str:
             return str(expr.value)
     
     elif isinstance(expr, BinaryOperation):
+        if expr.operator == "AS" and isinstance(expr.right, LiteralExpression):
+            return expr.right.value
+            
         left_code = _generate_expression(expr.left)
         right_code = _generate_expression(expr.right)
         

--- a/scripts/run_simple_select_test.py
+++ b/scripts/run_simple_select_test.py
@@ -96,7 +96,7 @@ def main():
         
         repl_pure_code = f"#>{{local::DuckDuckDatabase.employees}}#->select(~[id, name, salary])"
         
-        expected_pure = "$employees->select(~[$employees_0.id AS \"id\", $employees_0.name AS \"name\", $employees_0.salary AS \"salary\"])"
+        expected_pure = "$employees->select(~[id, name, salary])"
         if pure_code.strip() == expected_pure:
             print("Pure code generation validation: SUCCESS")
         else:

--- a/validate_pure_relation.py
+++ b/validate_pure_relation.py
@@ -1,0 +1,40 @@
+from cloud_dataframe.core.dataframe import DataFrame
+
+def main():
+    """Validate the issue with AS column aliases in pure relation syntax."""
+    # Create a simple DataFrame with a select operation
+    df = DataFrame.from_("employees", alias="employees_0")
+    
+    selected_df = df.select(
+        lambda employees_0: (id := employees_0.id),
+        lambda employees_0: (name := employees_0.name),
+        lambda employees_0: (salary := employees_0.salary)
+    )
+    
+    # Generate Pure code with pure_relation dialect
+    pure_code = selected_df.to_sql(dialect="pure_relation")
+    
+    print("\n=== Generated Pure Code ===")
+    print(pure_code.strip())
+    
+    # Expected format without AS clauses
+    expected_without_as = "$employees->select(~[id, name, salary])"
+    print("\n=== Expected Format (without AS) ===")
+    print(expected_without_as)
+    
+    # Current expected format with AS clauses
+    expected_with_as = "$employees->select(~[$employees_0.id AS \"id\", $employees_0.name AS \"name\", $employees_0.salary AS \"salary\"])"
+    print("\n=== Current Expected Format (with AS) ===")
+    print(expected_with_as)
+    
+    # Check if the generated code matches either format
+    if pure_code.strip() == expected_without_as:
+        print("\nVALIDATION: Code is correctly generated WITHOUT AS clauses")
+    elif pure_code.strip() == expected_with_as:
+        print("\nVALIDATION: Code is incorrectly generated WITH AS clauses")
+    else:
+        print("\nVALIDATION: Code format doesn't match either expected format")
+        print(f"Generated: {pure_code.strip()}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR fixes an issue in run_simple_select_test.py where the select() statement was incorrectly including AS column aliases in pure relation syntax.

Changes:
- Updated _apply_select function to prioritize column aliases
- Added special handling in _generate_expression for BinaryOperation with AS operator
- Updated test expectations to match correct syntax

Requested by: Neema Raphael
Link to Devin run: https://app.devin.ai/sessions/850615c202394b8d94387a64676cd662