### PR TITLE
Add support for column renaming in Pure language generator

### DIFF
--- a/cloud_dataframe/backends/pure_relation/generator.py
+++ b/cloud_dataframe/backends/pure_relation/generator.py
@@ -154,10 +154,16 @@ def _apply_select(relation_code: str, columns: List[Column]) -> str:
         The code for the relation with columns selected
     """
     cols = []
+    rename_operations = []
+    
     for col in columns:
         if isinstance(col, Column):
             if col.alias:
                 cols.append(col.alias)
+                
+                expr = col.expression
+                if isinstance(expr, ColumnReference):
+                    rename_operations.append((expr.name, col.alias))
             else:
                 expr = col.expression
                 if isinstance(expr, ColumnReference):
@@ -166,12 +172,27 @@ def _apply_select(relation_code: str, columns: List[Column]) -> str:
                     cols.append(_generate_expression(expr))
         elif isinstance(col, ColumnReference):
             cols.append(col.name)
+        elif isinstance(col, BinaryOperation) and col.operator == "AS":
+            if isinstance(col.right, LiteralExpression):
+                new_col_name = col.right.value
+                cols.append(new_col_name)
+                
+                if isinstance(col.left, ColumnReference):
+                    old_col_name = col.left.name
+                    rename_operations.append((old_col_name, new_col_name))
+                else:
+                    pass
         else:
             cols.append(_generate_expression(col))
             
     cols_code = ", ".join(cols)
     
-    return f"{relation_code}->select(~[{cols_code}])"
+    result = f"{relation_code}->select(~[{cols_code}])"
+    
+    for old_col, new_col in rename_operations:
+        result = f"{result}->rename('{old_col}', '{new_col}')"
+    
+    return result
 
 
 def _apply_group_by(relation_code: str, group_by_clauses: List[Expression], columns: List[Column]) -> str:

--- a/cloud_dataframe/backends/pure_relation/generator.py
+++ b/cloud_dataframe/backends/pure_relation/generator.py
@@ -190,7 +190,7 @@ def _apply_select(relation_code: str, columns: List[Column]) -> str:
     result = f"{relation_code}->select(~[{cols_code}])"
     
     for old_col, new_col in rename_operations:
-        result = f"{result}->rename('{old_col}', '{new_col}')"
+        result = f"{result}->rename(~{old_col}, ~{new_col})"
     
     return result
 

--- a/scripts/run_simple_select_test.py
+++ b/scripts/run_simple_select_test.py
@@ -95,7 +95,7 @@ def main():
         sql_code = selected_df.to_sql(dialect='duckdb')
         pure_code = selected_df.to_sql(dialect='pure_relation')
         
-        expected_pure = "$employees->select(~[id, name, salary])->rename('id', 'id')->rename('name', 'name')->rename('salary', 'salary')"
+        expected_pure = "$employees->select(~[id, name, salary])->rename(~id, ~id)->rename(~name, ~name)->rename(~salary, ~salary)"
         
         print('\n=== DataFrame Generated SQL ===')
         print(sql_code.strip())
@@ -125,7 +125,7 @@ def main():
         sql_code2 = selected_df2.to_sql(dialect='duckdb')
         pure_code2 = selected_df2.to_sql(dialect='pure_relation')
         
-        expected_pure2 = "$employees->select(~[employee_id, employee_name, employee_salary])->rename('id', 'employee_id')->rename('name', 'employee_name')->rename('salary', 'employee_salary')"
+        expected_pure2 = "$employees->select(~[employee_id, employee_name, employee_salary])->rename(~id, ~employee_id)->rename(~name, ~employee_name)->rename(~salary, ~employee_salary)"
         
         print('\n=== DataFrame Generated SQL ===')
         print(sql_code2.strip())


### PR DESCRIPTION
# Add support for column renaming in Pure language generator

This PR adds support for column renaming in the Dataframe DSL to Pure language generator.

## Changes:
- Modified pure_relation/generator.py to handle column renaming using rename()
- For each walrus operator in a DSL select(), generates a corresponding Pure rename() function call
- Each column is renamed individually since rename() only handles one column at a time
- Updated run_simple_select_test.py to test column renaming functionality

## Tests:
- Added test cases for basic column renaming and renaming with different column names
- Both test cases pass successfully

Link to Devin run: https://app.devin.ai/sessions/752dcc0abe034cab814bb25dfa3d5f46
Requested by: neema.raphael@gs.com